### PR TITLE
Firecracker sanity check

### DIFF
--- a/common/src/lookup.rs
+++ b/common/src/lookup.rs
@@ -21,6 +21,23 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-pub mod lookup;
-pub mod user;
-pub mod error;
+use std::env;
+use std::fs;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Lookup {
+}
+
+impl Lookup {
+    pub fn which(command: &str) -> bool {
+        if let Ok(path) = env::var("PATH") {
+            for path_entry in path.split(':') {
+                let abs_command = format!("{}/{}", path_entry, command);
+                if fs::metadata(abs_command).is_ok() {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -23,6 +23,8 @@
 //
 use std::env;
 
+pub const FIRECRACKER: &str =
+    "firecracker";
 pub const IMAGE_ROOT: &str =
     "image";
 pub const IMAGE_OVERLAY: &str =

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -23,6 +23,7 @@
 //
 use std::{thread, time};
 use flakes::user::User;
+use flakes::lookup::Lookup;
 use spinoff::{Spinner, spinners, Color};
 use ubyte::ByteUnit;
 use std::path::Path;
@@ -153,6 +154,10 @@ pub fn create(
       for the later VM process ID and and the name of
       the VM ID file.
     !*/
+    if ! Lookup::which(defaults::FIRECRACKER) {
+        panic!("{} not found in $PATH, installed ?", defaults::FIRECRACKER)
+    }
+
     let mut result: Vec<String> = Vec::new();
 
     // setup VM ID file name
@@ -379,7 +384,7 @@ pub fn call_instance(
     !*/
     let mut status_code = 0;
 
-    let mut firecracker = user.run("firecracker");
+    let mut firecracker = user.run(defaults::FIRECRACKER);
     if ! is_debug() {
         firecracker.stderr(Stdio::null());
     }


### PR DESCRIPTION
The firecracker startup procedure in resume mode needs to setup the control channels prior launching the actual firecracker program to allow synchronisation of guest vs. host data flow. If there is no check that the firecracker binary exists we still perform all the pre setup and waiting calls and the actual error condition is only visible in debug mode. Therefore an early exit condition that checks if there is a firecracker binary found on the host improves the user experience. This Fixes #129