### PR TITLE
Delete meta authors information

### DIFF
--- a/flake-ctl/Cargo.toml
+++ b/flake-ctl/Cargo.toml
@@ -1,11 +1,6 @@
 [package]
 name = "flake-ctl"
 version = "2.2.24"
-authors = [
-    "Michael Meyer <mijomeyer@t-online.de>",
-    "Marcin Katulski <marcin.katulski@gmail.com>",
-    "Marcus Schäfer <marcus.schaefer@gmail.com>"
-]
 edition = "2018"
 license = "MIT"
 


### PR DESCRIPTION
The authors information at this point was used in the cli interface and printed on the console in the usage information. Exposing this information might be unwanted and the information is also printed in a not well formatted way.