### PR TITLE
Fixed firecracker serde schema

### DIFF
--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -170,6 +170,7 @@ pub struct EngineSection<'a> {
 #[derive(Debug, Deserialize, Clone, Display)]
 pub enum CacheType {
     Writeback,
+    Unsafe
 }
 
 impl Default for CacheType {


### PR DESCRIPTION
Allowed values for cache_type are Writeback and Unsafe