### PR TITLE
Force cleanup of resume type flakes

### DIFF
--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -14,4 +14,5 @@ spinoff = { version = "0.7" }
 lazy_static = { version = "1.4" }
 serde = { version = "1.0", features = ["derive"]}
 serde_yaml = { version = "0.9" }
+regex = { version = "1.9" }
 flakes = { version = "3.0.1", path = "../common" }


### PR DESCRIPTION
In case a resume type flake has lost its cid metadata which can
happen on e.g powerfail, the resume of the instance should cleanup
the left over container instance and start from scratch.

This Fixes #23
