### PR TITLE
Fix workspace resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ lto = false
 strip = false
 
 [workspace]
+resolver = "2"
 members = [
     "flake-ctl", 
     "podman-pilot", 


### PR DESCRIPTION
Edition 2021 is used in several src setup which implies workspace resolver version 2. Make this a permanent setting and don't let it assume an implicit resolver version