### PR TITLE
Prevent use of socat in sci

### DIFF
--- a/.github/workflows/ci-compile.yml
+++ b/.github/workflows/ci-compile.yml
@@ -24,4 +24,4 @@ jobs:
           sudo mv /bin/sh.bash /bin/sh
       - name: Compile
         run: |
-          make cargo
+          make compile

--- a/firecracker-pilot/guestvm-tools/sci/Cargo.toml
+++ b/firecracker-pilot/guestvm-tools/sci/Cargo.toml
@@ -11,3 +11,5 @@ sys-mount = { version = "2.0", default-features = false, features = [] }
 system_shutdown = { version = "4.0" }
 shell-words = { version = "1.1" }
 vsock = { version = "0.3" }
+libc = { version = "0.2" }
+pty = { version = "0.2" }

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -130,7 +130,6 @@ execution interface
 %package -n flake-pilot-firecracker-guestvm-tools
 Summary:        FireCracker guest VM tools
 Group:          System/Management
-Requires:       socat
 
 %description -n flake-pilot-firecracker-guestvm-tools
 Guest VM tools to help with firecracker workloads


### PR DESCRIPTION
Replace external socat call in sci with rust implementation based on the pty, libc and vsock crates.

This Fixes #8
