### PR TITLE
Make sure system mount point exists for sci

### DIFF
--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -33,7 +33,6 @@ pub const PROBE_MODULE: &str = "/sbin/modprobe";
 pub const SYSTEMD_NETWORK_RESOLV_CONF: &str = "/run/systemd/resolve/resolv.conf";
 pub const VM_QUIT: &str = "sci_quit";
 pub const VHOST_TRANSPORT: &str = "vmw_vsock_virtio_transport";
-pub const SOCAT: &str = "/usr/bin/socat";
 pub const VM_PORT: u32 = 52;
 pub const GUEST_CID: u32 = 3;
 

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -160,7 +160,7 @@ fn main() {
                             defaults::OVERLAY_UPPER, defaults::OVERLAY_WORK
                         )
                     )
-                    .mount("overlay", "/overlayroot/rootfs")
+                    .mount("overlay", defaults::OVERLAY_ROOT)
                 {
                     Ok(_) => {
                         debug(&format!(

--- a/firecracker-pilot/src/main.rs
+++ b/firecracker-pilot/src/main.rs
@@ -47,9 +47,6 @@ fn main() -> ExitCode {
 
     let result = run();
 
-    // TODO: implement cleanup function 
-    // cleanup()
-
     match result {
         Ok(()) => ExitCode::SUCCESS,
         Err(err) => {
@@ -60,7 +57,6 @@ fn main() -> ExitCode {
 }
 
 fn run() -> Result<(), FlakeError> {
-
     let program_path = app_path::program_abs_path();
     let program_name = app_path::basename(&program_path);
 

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -171,8 +171,24 @@ pub async fn pull_component_image(
                 let sci_in_image = format!(
                     "{}/{}", tmp_dir_path, "/usr/sbin/sci"
                 );
+                // required for overlay mount process
                 let overlay_root_in_image = format!(
                     "{}/{}", tmp_dir_path, "/overlayroot"
+                );
+                // required for /proc/sys/kernel/sysrq based force_reboot
+                let proc_in_image = format!(
+                    "{}/{}", tmp_dir_path, "/proc"
+                );
+                // required for pivot
+                let sys_in_image = format!(
+                    "{}/{}", tmp_dir_path, "/sys"
+                );
+                let dev_in_image = format!(
+                    "{}/{}", tmp_dir_path, "/dev"
+                );
+                // required for PTS allocation
+                let dev_pts_in_image = format!(
+                    "{}/{}", tmp_dir_path, "/dev/pts"
                 );
                 if ! Path::new(&sci_in_image).exists() {
                     info!("Copying sci to rootfs...");
@@ -184,6 +200,22 @@ pub async fn pull_component_image(
                     }
                 }
                 if ! Path::new(&overlay_root_in_image).exists() && ! mkdir(&overlay_root_in_image, "root") {
+                    umount(&tmp_dir_path, "root");
+                    return result
+                }
+                if ! Path::new(&proc_in_image).exists() && ! mkdir(&proc_in_image, "root") {
+                    umount(&tmp_dir_path, "root");
+                    return result
+                }
+                if ! Path::new(&sys_in_image).exists() && ! mkdir(&sys_in_image, "root") {
+                    umount(&tmp_dir_path, "root");
+                    return result
+                }
+                if ! Path::new(&dev_in_image).exists() && ! mkdir(&dev_in_image, "root") {
+                    umount(&tmp_dir_path, "root");
+                    return result
+                }
+                if ! Path::new(&dev_pts_in_image).exists() && ! mkdir(&dev_pts_in_image, "root") {
                     umount(&tmp_dir_path, "root");
                     return result
                 }


### PR DESCRIPTION
Reboot, terminal allocation and pivot of a firecracker machine requires access to sysrq, pts devices and more. sci mounts all kernel filesystems but this requires the mountpoints /proc, /sys /dev, /dev/pts to be available. Some prebuild firecracker images comes without these mountpoints (non FHS compliant btw). With this commit we make sure that at registration time the image has this mountpoint such that the sci issued system mounts can succeed.