### PR TITLE
Add support for force vsock on firecracker pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,19 @@ Start an application as virtual machine (VM) instance as follows:
    Our default setting prevents kernel messages from being printed to
    the console as much as possible but there are message that can hardly
    be prevented or requires a customized kernel build to be suppressed.
-   As all messages are fetched from the serial console there is also
-   no differentiation between **stdout** and **stderr** anymore.
+   If this is unwanted use the
+
+   ```bash
+   --force-vsock
+   ```
+
+   option when registering the application.
+
+   There are still limitations such as that there is also
+   no differentiation between **stdout** and **stderr** anymore
+   and the exit code of the VM call is not matching the exit
+   code of the application call.
+
 
 ### Use FireCracker VM image from components <a name="components"/>
 

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -21,6 +21,7 @@ SYNOPSIS
        --include-path <INCLUDE_PATH>...
        --no-net
        --resume
+       --force-vsock
        --overlay-size <OVERLAY_SIZE>
        --run-as <RUN_AS>
        --target <TARGET>
@@ -74,6 +75,12 @@ OPTIONS
 
   Resume the VM from previous execution. If the VM is still running,
   the app will be executed inside of this VM instance
+
+--force-vsock
+
+  Force using a vsock to communicate between guest and
+  host if resume is set to false. In resume mode the vsock
+  setup is always required.
 
 --run-as <RUN_AS>
 

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -167,6 +167,14 @@ pub struct RuntimeSection<'a> {
     #[serde(default)]
     pub resume: bool,
 
+    /// Force using a vsock to communicate between guest and
+    /// host if resume is set to false. In resume mode the
+    /// vsock setup is always required.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub force_vsock: bool,
+
     pub firecracker: EngineSection<'a>,
 }
 

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -157,6 +157,7 @@ pub fn create_vm_config(
     overlay_size: Option<&String>,
     no_net: bool,
     resume: bool,
+    force_vsock: bool,
     includes_tar: Option<Vec<String>>,
     includes_path: Option<Vec<String>>,
 ) -> bool {
@@ -185,6 +186,7 @@ pub fn create_vm_config(
         overlay_size,
         no_net,
         resume,
+        force_vsock,
         includes_tar,
         includes_path,
     ) {

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -142,6 +142,12 @@ pub enum Firecracker {
         #[clap(long)]
         resume: bool,
 
+        /// Force using a vsock to communicate between guest and
+        /// host if resume is set to false. In resume mode the
+        /// vsock setup is always required.
+        #[clap(long)]
+        force_vsock: bool,
+
         /// Size of overlay write space in bytes.
         /// Optional suffixes: KiB/MiB/GiB/TiB (1024) or KB/MB/GB/TB (1000)
         #[clap(long)]

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -81,7 +81,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                 // register
                 cli::Firecracker::Register {
                     vm, app, target, run_as, overlay_size, no_net, resume,
-                    include_tar, include_path
+                    force_vsock, include_tar, include_path
                 } => {
                     if app::init(Some(app)) {
                         let mut ok = app::register(
@@ -97,6 +97,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                                 overlay_size.as_ref(),
                                 *no_net,
                                 *resume,
+                                *force_vsock,
                                 include_tar.as_ref().cloned(),
                                 include_path.as_ref().cloned(),
                             );

--- a/flake-ctl/template/firecracker-flake.yaml
+++ b/flake-ctl/template/firecracker-flake.yaml
@@ -10,6 +10,7 @@ vm:
   runtime:
     runas: root
     resume: false
+    force_vsock: false
     firecracker:
       boot_args:
         - "init=/usr/sbin/sci"


### PR DESCRIPTION
The vsock communication between guest and host was established with the firecracker pilot only for resume type registrations. For those it's required because you cannot mux one serial terminal between parallel applications running at the same time in the guest. So in resume mode each call has its own socket and channels. However, there is no reason to not also support that type of data flow between guest and host for one time calls which fires up the VM, starts the application and shuts down the VM. This commit adds support for forcing the vsock communication also for the simple app registration. The default stays on serial though.