### PR TITLE
Prevent use of socat in firecracker-pilot

### DIFF
--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -18,3 +18,4 @@ lazy_static = { version = "1.4" }
 serde_yaml = { version = "0.9" }
 strum = { version = "0.25", features = ["derive"] }
 flakes = { version = "3.0.10 ", path = "../common", features = ["json"] }
+libc = { version = "0.2" }

--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -35,6 +35,10 @@ pub const VM_QUIT: &str = "sci_quit";
 pub const VHOST_TRANSPORT: &str = "vmw_vsock_virtio_transport";
 pub const VM_PORT: u32 = 52;
 pub const GUEST_CID: u32 = 3;
+pub const RETRIES: u32 =
+    5;
+pub const VM_WAIT_TIMEOUT_MSEC: u64 =
+    100;
 
 pub fn debug(message: &str) {
     if env::var("PILOT_DEBUG").is_ok() {

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -45,8 +45,6 @@ pub const GC_THRESHOLD: usize = 20;
 pub const VM_CID: u32 = 3;
 pub const VM_PORT: u32 =
     52;
-pub const SOCAT: &str =
-    "/usr/bin/socat";
 pub const RETRIES: u32 =
     60;
 pub const VM_WAIT_TIMEOUT_MSEC: u64 =

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -86,7 +86,6 @@ Requires:       rsync
 Requires:       firecracker
 Requires:       xz
 Requires:       e2fsprogs
-Requires:       socat
 Requires:       sudo
 
 %description -n flake-pilot-firecracker


### PR DESCRIPTION
Do not shell out socat and use proper UnixListener/UnixStream to do this job. This version of the commit works but I stumbled across a few issues:

1. Permission denied when the UnixListener runs as user and the firecracker process was called as root (run_as: root in the flake). The former implementation ran socat via sudo in the same way as the firecracker process. Thus if you register the flake to run as root it can now also only be called as root, which is acceptable.

2. The behavior in interactive sessions differs compared to socat. When sci in the guest is called it creates a pty and all data is copied to the vsock stream. The host connects via an UDS socket to this data and we multiplex stdin->stream and stream->stdout. When doing this with socat the behavior is different in a way that e.g tabs are effectively interpreted and the pty prompt allows for input on the same line when my code now always needs a newline to renew the prompt. I did not debug further what is needed to make this look nicer.