### PR TITLE
Handle incomplete container path

### DIFF
--- a/doc/flake-ctl-podman-load.rst
+++ b/doc/flake-ctl-podman-load.rst
@@ -21,7 +21,10 @@ SYNOPSIS
 DESCRIPTION
 -----------
 
-Load the given OCI image into the local registry.
+Load the given OCI image into the local registry. If the provided
+file path cannot be found and attempt is made to match the image using
+the provided path as the base for a glob. If multiple images match the
+glob the highest image in alpha numerical order will be loaded.
 The command is based on **podman load**. After completion
 the container can be listed via:
 

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -198,6 +198,9 @@ pub enum Podman {
     /// Load container
     Load {
         /// OCI image to load into local podman registry
+        /// used as the base of a glob if the given image path
+        /// is not found. Load the highest, in alpha numerical order
+        /// image if there is a match
         #[clap(long)]
         oci: String,
     },

--- a/flake-ctl/src/podman.rs
+++ b/flake-ctl/src/podman.rs
@@ -83,11 +83,8 @@ pub fn load(oci: &String) -> i32 {
         // glob puts things in alpha sorted order which is expected to give
         // us the highest version of the archive
         for entry in glob(&container_archives)
-            .expect("Failed to read glob pattern") {
-                match entry {
-                    Ok(path) => container_archive = path.display().to_string(),
-                    Err(_) => {},
-                }
+            .expect("Failed to read glob pattern").flatten() {
+                    container_archive = entry.display().to_string()
             }
         }
     info!("podman load -i {}", container_archive);


### PR DESCRIPTION
At present in order to load a container the full file name must be specified. In an automated setup where the container is delivered by a source such as an RPM package and then loaded by another process the exact filename may not be known. We expect that the user provide the path to the tarball including the beginning of the archive name. If multiple archives match the highest file based on alpha-numeric sorting is used to load as a container.