### PR TITLE
Doc clarification

### DIFF
--- a/doc/flake-ctl-podman-register.rst
+++ b/doc/flake-ctl-podman-register.rst
@@ -44,6 +44,13 @@ like a normal application on this host.
 For further details about the flake configuration please refer to
 the **podman-pilot** manual page.
 
+NOTE
+----
+
+References made to the name of a container or container name imply the
+path of the container as it is known in the local registry. The value shown
+in the **REPOSITORY** column shown by the **podman images** command.
+
 OPTIONS
 -------
 


### PR DESCRIPTION
Using the term "container name" can be confusing and interpreted as simply the name of the container itself. What we really need to make registration work is the path of the container in the local registry. Clarify the documentation by adding a not ethat points out this potential pitfall.