### PR TITLE
Fixed the runroot permission fixup

### DIFF
--- a/common/src/container.rs
+++ b/common/src/container.rs
@@ -28,7 +28,7 @@ use crate::flakelog::FlakeLog;
 use crate::error::FlakeError;
 use crate::user::User;
 use crate::command::CommandExtTrait;
-use users::{get_current_uid, get_current_gid, get_current_username};
+use users::{get_current_uid, get_current_gid};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Container {
@@ -58,14 +58,13 @@ impl Container {
         let root = User::from("root");
         let user_id = get_current_uid();
         let user_gid = get_current_gid();
-        let current_user = get_current_username().unwrap();
         let chown_param = format!("{}:{}", user_id, user_gid);
 
         let mut fix_run_storage = root.run("chown");
         fix_run_storage.arg("-R")
             .arg(chown_param)
             .arg("/run/libpod")
-            .arg(format!("/run/flakes/{}", current_user.to_str().unwrap()));
+            .arg(defaults::FLAKES_REGISTRY_RUNROOT);
         FlakeLog::debug(&format!("{:?}", fix_run_storage.get_args()));
         fix_run_storage.perform()?;
 

--- a/common/src/defaults.rs
+++ b/common/src/defaults.rs
@@ -27,3 +27,4 @@ pub const PODMAN_IDS_DIR: &str = "/tmp/flakes";
 pub const FIRECRACKER_IDS_DIR: &str = "/tmp/flakes";
 pub const FLAKES_STORAGE: &str = "/etc/flakes/storage.conf";
 pub const FLAKES_REGISTRY: &str = "/usr/share/flakes/storage";
+pub const FLAKES_REGISTRY_RUNROOT: &str = "/run/flakes";


### PR DESCRIPTION
podman differentiates the runroot between root and rootless calls. If you initially call a flake as a user the initial podman database gets setup as rootless variant which also allows root based workloads without permission issues. However, if you do it the other way round the runroot is setup for root only which prevents the flake to be called as normal user. To handle this permission issues we have fix methods in the flake common code to change the permissions according to the calling user via sudo. The code to handle permissions for the runroot target has to apply for all users as we can't predict if the storage will be setup initially as rootless or for root only