### PR TITLE
Fixed podman call dead lock

### DIFF
--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -148,6 +148,10 @@ OPTIONS
   even if there are files missing. This can lead to a non functional
   instance of course, you have been warned.
 
+%interactive
+
+  Use when running interactive processes like a shell
+
 DEBUGGING
 ---------
 


### PR DESCRIPTION
When calling the flake and stdout/stderr gets redirected into a pipe like `flake | grep ... | cut ...` the pilot binary runs in a dead lock because there is no reader/writer to feed the pipe from the child process (podman) executed via the pilot. This commit fixes it by making sure all data from the child gets read first and then passed along to stdout/stderr of the caller.