### PR TITLE
Automatically detect terminal mode

### DIFF
--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -150,7 +150,10 @@ OPTIONS
 
 %interactive
 
-  Use when running interactive processes like a shell
+  Force interactive call style for processes like a shell.
+  Usually the pilot automatically detects if called in a
+  terminal or not. This options allows to override the
+  detection.
 
 DEBUGGING
 ---------

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -18,3 +18,4 @@ regex = { version = "1.9" }
 flakes = { version = "3.1.11", path = "../common" }
 rust-ini = { version = "0.21" }
 users = { version = "0.11" }
+atty = { version = "0.2" }

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -25,6 +25,8 @@
 use crate::defaults;
 use crate::config::{RuntimeSection, config};
 
+use atty::Stream;
+
 use flakes::user::{User, mkdir};
 use flakes::lookup::Lookup;
 use flakes::io::IO;
@@ -520,7 +522,7 @@ pub fn call_instance(
     if Lookup::is_debug() {
         debug!("{:?}", call.get_args());
     }
-    if interactive {
+    if interactive || atty::is(Stream::Stdout) {
         call.status()?;
     } else {
         match call.output() {


### PR DESCRIPTION
We support the `%interactive` flag to set interactive commands. With this commit I added a terminal detection such that we normally get dropped into the right caller type but still can overwrite the detection via the mentioned option