### PR TITLE
Fix container cleanup

### DIFF
--- a/.github/workflows/ci-robot-tests.yml
+++ b/.github/workflows/ci-robot-tests.yml
@@ -27,7 +27,7 @@ jobs:
         run:  python3 -m robot robot_tests
       - name: Upload Log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: robot-log
           path: /home/runner/work/flake-pilot/flake-pilot/log.html

--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -163,6 +163,15 @@ OPTIONS
   terminal or not. This options allows to override the
   detection.
 
+%remove
+
+  When running in attach or resume mode, podman-pilot keeps the
+  container created such that the call of the same flake can either
+  start/attach the container with its entry command or execute
+  the command in the resume/running container. If the container
+  should be removed at the end of the process execution, pass
+  this flake option to the call.
+
 DEBUGGING
 ---------
 

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -400,7 +400,7 @@ fn main() {
         if do_exec {
             // replace ourselves
             debug(&format!("EXEC: {} -> {:?}", &args[0], call.get_args()));
-            call.exec();
+            let _ = call.exec();
         } else {
             // call a command and keep control
             debug(&format!(

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -509,8 +509,6 @@ pub fn call_instance(
     /*!
     Call container ID based podman commands
     !*/
-    let args: Vec<String> = env::args().collect();
-
     let RuntimeSection { resume, .. } = config().runtime();
 
     let pilot_options = Lookup::get_pilot_run_options();
@@ -542,10 +540,8 @@ pub fn call_instance(
         call.arg(
             get_target_app_path(program_name)
         );
-        for arg in &args[1..] {
-            if ! arg.starts_with('@') {
-                call.arg(arg);
-            }
+        for arg in Lookup::get_run_cmdline(Vec::new(), false) {
+            call.arg(arg);
         }
     }
     if Lookup::is_debug() {

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -182,9 +182,9 @@ pub fn create(
     }
 
     // create the container with configured runtime arguments
+    let var_pattern = Regex::new(r"%([A-Z]+)").unwrap();
     for arg in podman.iter().flatten().flat_map(|x| x.splitn(2, ' ')) {
         let mut arg_value = arg.to_string();
-        let var_pattern = Regex::new(r"%([A-Z]+)").unwrap();
         while var_pattern.captures(&arg_value.clone()).is_some() {
             for capture in var_pattern.captures_iter(&arg_value.clone()) {
                 // replace %VAR placeholder(s) with the respective
@@ -462,7 +462,7 @@ pub fn start(program_name: &str, cid: &str) -> Result<(), FlakeError> {
     let user = User::from(current_user.to_str().unwrap());
 
     let is_running = container_running(cid, user)?;
-    let is_created = container_exists(&cid, user)?;
+    let is_created = container_exists(cid, user)?;
     let mut is_removed = false;
 
     if is_running {


### PR DESCRIPTION
**Fix container cleanup**
    
A flake configured to be attached can also be re-started using the same container storage. However, the container was always removed when the command exited. This commit fixes it to avoid removing the container of attach type flakes. In addition a flake option %remove was added to allow removing the container created for resume and attach  type flakes

**Fix building runtime arguments**
    
Use get_run_cmdline method everywhere
