### PR TITLE
kill prior remove when using %remove flag

### DIFF
--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -498,6 +498,7 @@ pub fn start(program_name: &str, cid: &str) -> Result<(), FlakeError> {
     };
 
     if pilot_options.contains_key("%remove") && ! is_removed {
+        call_instance("kill", cid, program_name, user)?;
         call_instance("rm_force", cid, program_name, user)?;
     };
     Ok(())


### PR DESCRIPTION
In case the container instance should be removed via the %remove flag, send a kill first, followed by a force remove. The reason for this is because we use a never ending sleep command as entry point for resume type containers. If they should be removed the standard signal send on podman rm will not stop the sleep and after a period of 10 seconds podman sends a kill signal itself. We can speedup this process as we know the entry point command and send the kill signal first followed by the remove which saves us some wait time spent in podman otherwise.