### PR TITLE
Create sequence number for the same invocation

### DIFF
--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -108,7 +108,7 @@ pub struct Config<'a> {
 }
 
 impl<'a> Config<'a> {
-    pub fn runtime(&self) -> RuntimeSection {
+    pub fn runtime(&self) -> RuntimeSection<'_> {
         self.vm.runtime.as_ref().cloned().unwrap_or_default()
     }
 

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -126,10 +126,8 @@ impl AppConfig {
         if check_host_dependencies {
             container_config.check_host_dependencies = check_host_dependencies
         }
-        if layers.is_some() {
-            container_config.layers = Some(
-                layers.as_ref().unwrap().to_vec()
-            );
+        if let Some(layers) = &layers {
+            container_config.layers = Some(layers.to_vec());
         }
         if resume {
             container_config.runtime.as_mut().unwrap()
@@ -142,19 +140,15 @@ impl AppConfig {
             container_config.runtime.as_mut().unwrap()
                 .runas = Some(run_as.to_string());
         }
-        if includes_tar.is_some() {
-            yaml_config.include.tar = Some(
-                includes_tar.as_ref().unwrap().to_vec()
-            );
+        if let Some(includes_tar) = &includes_tar {
+            yaml_config.include.tar = Some(includes_tar.to_vec());
         }
-        if includes_path.is_some() {
-            yaml_config.include.path = Some(
-                includes_path.as_ref().unwrap().to_vec()
-            );
+        if let Some(includes_path) = &includes_path {
+            yaml_config.include.path = Some(includes_path.to_vec());
         }
-        if opts.is_some() {
+        if let Some(opts) = &opts {
             let mut final_opts: Vec<String> = Vec::new();
-            for opt in opts.as_ref().unwrap() {
+            for opt in opts {
                 if let Some(stripped_opt) = opt.strip_prefix('\\') {
                     final_opts.push(stripped_opt.to_string())
                 } else {
@@ -220,15 +214,11 @@ impl AppConfig {
             vm_config.runtime.as_mut().unwrap()
                 .runas = Some(run_as.to_string());
         }
-        if includes_tar.is_some() {
-            yaml_config.include.tar = Some(
-                includes_tar.as_ref().unwrap().to_vec()
-            );
+        if let Some(includes_tar) = &includes_tar {
+            yaml_config.include.tar = Some(includes_tar.to_vec());
         }
-        if includes_path.is_some() {
-            yaml_config.include.path = Some(
-                includes_path.as_ref().unwrap().to_vec()
-            );
+        if let Some(includes_path) = &includes_path {
+            yaml_config.include.path = Some(includes_path.to_vec());
         }
         if let Some(overlay_size) = overlay_size {
             vm_config.runtime.as_mut().unwrap()

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -19,3 +19,4 @@ flakes = { version = "3.1.20", path = "../common" }
 rust-ini = { version = "0.21" }
 uzers = { version = "0.12" }
 atty = { version = "0.2" }
+rand = { version = "0.9" }

--- a/podman-pilot/Cargo.toml
+++ b/podman-pilot/Cargo.toml
@@ -20,3 +20,4 @@ rust-ini = { version = "0.21" }
 uzers = { version = "0.12" }
 atty = { version = "0.2" }
 rand = { version = "0.9" }
+rand_chacha = { version = "0.9" }

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -109,7 +109,7 @@ impl<'a> Config<'a> {
         self.container.base_container.is_some()
     }
 
-    pub fn runtime(&self) -> RuntimeSection {
+    pub fn runtime(&self) -> RuntimeSection<'_> {
         self.container.runtime.as_ref().cloned().unwrap_or_default()
     }
 

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -27,7 +27,7 @@ use crate::config::{RuntimeSection, config};
 
 use atty::Stream;
 use rand::prelude::*;
-use rand_chacha::ChaCha8Rng;
+use rand_chacha::ChaCha20Rng;
 
 use flakes::user::{User, mkdir};
 use flakes::lookup::Lookup;
@@ -130,12 +130,12 @@ pub fn create(
     // If no @NAME is assigned and the flake is not a resume flake
     // and not an attach flake, a random seed sequence_number
     // considered collision free is used as described in:
-    // https://rust-random.github.io/book/guide-seeding.html#a-simple-number
+    // https://rust-random.github.io/book/guide-seeding.html#fresh-entropy
     let (name_value, _): (Vec<_>, Vec<_>) = env::args()
         .skip(1).partition(|arg| arg.starts_with('@'));
     let name = name_value.first().map(String::as_str).unwrap_or("");
     let suffix = if name.is_empty() && ! (resume || attach) {
-        let mut rng = ChaCha8Rng::seed_from_u64(2);
+        let mut rng = ChaCha20Rng::from_os_rng();
         let sequence_number: u32 = rng.random();
         format!("@NAME={sequence_number}")
     } else {

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -26,7 +26,8 @@ use crate::defaults;
 use crate::config::{RuntimeSection, config};
 
 use atty::Stream;
-use rand::Rng;
+use rand::prelude::*;
+use rand_chacha::ChaCha8Rng;
 
 use flakes::user::{User, mkdir};
 use flakes::lookup::Lookup;
@@ -118,19 +119,28 @@ pub fn create(
     container ID and and the name of the container ID
     file.
     !*/
-    // Read optional @NAME pilot argument to differentiate
-    // simultaneous instances of the same container application
-    let (name, _): (Vec<_>, Vec<_>) = env::args()
-        .skip(1).partition(|arg| arg.starts_with('@'));
-
-    // setup container ID file name
-    let suffix = name.first().map(String::as_str).unwrap_or("");
-
     // setup app command path name to call
     let target_app_path = get_target_app_path(program_name);
 
     // get runtime section
     let RuntimeSection { resume, attach, podman, .. } = config().runtime();
+
+    // Read optional @NAME pilot argument to differentiate
+    // simultaneous instances of the same container application.
+    // If no @NAME is assigned and the flake is not a resume flake
+    // and not an attach flake, a random seed sequence_number
+    // considered collision free is used as described in:
+    // https://rust-random.github.io/book/guide-seeding.html#a-simple-number
+    let (name_value, _): (Vec<_>, Vec<_>) = env::args()
+        .skip(1).partition(|arg| arg.starts_with('@'));
+    let name = name_value.first().map(String::as_str).unwrap_or("");
+    let suffix = if name.is_empty() && ! (resume || attach) {
+        let mut rng = ChaCha8Rng::seed_from_u64(2);
+        let sequence_number: u32 = rng.random();
+        format!("@NAME={sequence_number}")
+    } else {
+        name.to_string()
+    };
 
     // provisioning needs root permissions for mount
     // make sure we have them for this session
@@ -143,9 +153,10 @@ pub fn create(
     let current_user = get_current_username().unwrap();
     let user = User::from(current_user.to_str().unwrap());
 
-    let mut container_cid_file = format!(
-        "{}/{}{suffix}_{}.cid",
-        get_podman_ids_dir(), program_name, current_user.to_str().unwrap()
+    let container_cid_file = format!(
+        "{}/{}{}_{}.cid",
+        get_podman_ids_dir(), program_name, suffix,
+        current_user.to_str().unwrap()
     );
 
     let container_runroot = format!(
@@ -178,23 +189,6 @@ pub fn create(
 
     // Garbage collect occasionally
     gc(user)?;
-
-    // Sanity check. Auto assign a random sequence number
-    // if a container for the same invocation already exists
-    if Path::new(&container_cid_file).exists() {
-        let mut rng = rand::rng();
-        let sequence_number: u32 = rng.random();
-        container_cid_file = format!(
-            "{}/{}@NAME={}_{}.cid",
-            get_podman_ids_dir(),
-            program_name,
-            sequence_number,
-            current_user.to_str().unwrap()
-        );
-        app = user.run("podman");
-        app.arg("create")
-            .arg("--cidfile").arg(&container_cid_file);
-    }
 
     // create the container with configured runtime arguments
     let var_pattern = Regex::new(r"%([A-Z]+)").unwrap();


### PR DESCRIPTION
If a flake which is not a resume or attach flake is called twice with the same invocation arguments an error message is displayed to give this invocation a new name via the `@NAME` runtime option. This commit makes this more comfortable and automatically assigns a random sequence number for the call if no `@NAME` is given.