### PR TITLE
Manage firecracker pilot with systemd-tmpfiles for SUSE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ package: clean vendor sourcetar
 	cp package/flake-pilot.spec package/build
 	cp package/cargo_config package/build
 	cp package/flake-pilot-rpmlintrc package/build
+	cp package/systemd-tmpfiles-for-suse.conf package/build
 	# update changelog using reference file
 	helper/update_changelog.py --since package/flake-pilot.changes.ref > \
 		package/build/flake-pilot.changes

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -31,6 +31,8 @@ URL:            https://github.com/OSInside/flake-pilot
 Source0:        %{name}.tar.gz
 Source1:        cargo_config
 Source2:        %{name}-rpmlintrc
+# SUSE-specific source additions (1001+)
+Source1001:     systemd-tmpfiles-for-suse.conf
 %if 0%{?debian} || 0%{?ubuntu}
 Requires:       golang-github-containers-common
 %endif
@@ -141,9 +143,12 @@ make DESTDIR=%{buildroot}/ install_sci
 mkdir -p %{buildroot}/overlayroot
 mkdir -p %{buildroot}/usr/lib/flake-pilot
 
+%if 0%{?suse_version} >= 1600
+install -D -m 644 %{SOURCE1001} %{buildroot}%{_tmpfilesdir}/flake-pilot-firecracker.conf
+%else
 mkdir -p %{buildroot}/var/lib/firecracker/images
-
 mkdir -p %{buildroot}/var/lib/firecracker/storage
+%endif
 
 mkdir -p %{buildroot}/etc/dracut.conf.d
 mkdir -p %{buildroot}/usr/lib/dracut/modules.d/80netstart
@@ -180,9 +185,16 @@ install -m 644 flakes.yml %{buildroot}/etc/flakes.yml
 %doc /usr/share/man/man8/podman-pilot.8.gz
 
 %files -n flake-pilot-firecracker
+%if 0%{?suse_version} >= 1600
+%{_tmpfilesdir}/flake-pilot-firecracker.conf
+%ghost %dir /var/lib/firecracker
+%ghost %dir /var/lib/firecracker/images
+%ghost %dir /var/lib/firecracker/storage
+%else
 %dir /var/lib/firecracker
 %dir /var/lib/firecracker/images
 %dir /var/lib/firecracker/storage
+%endif
 %dir /usr/lib/flake-pilot
 %config /etc/flakes/firecracker-flake.yaml
 %config /etc/flakes/firecracker.json

--- a/package/systemd-tmpfiles-for-suse.conf
+++ b/package/systemd-tmpfiles-for-suse.conf
@@ -1,0 +1,3 @@
+d /var/lib/firecracker
+d /var/lib/firecracker/images
+d /var/lib/firecracker/storage


### PR DESCRIPTION
Store firecracker images and the storage blob to
/usr/share/firecracker instead of /var/lib/firecracker. This serves the needs for SUSE's immutable mode and is also more consistent with other flake files e.g /usr/share/flakes. This Fixes jira#1054