### PR TITLE
Reverse showing progress logic

### DIFF
--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -148,9 +148,9 @@ OPTIONS
   between guest and host in a resume based flake setup. By default
   firecracker-pilot calculates a port number itself.
 
-%silent
+%progress
 
-  This stops the progress spinner to be displayed
+  Show a progress spinner as long as the pilot provisions
 
 DEBUGGING
 ---------

--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -144,9 +144,9 @@ OPTIONS
   This allows users to distribute the exact same program call to different
   instances when using a non resume based flake setup.
 
-%silent
+%progress
 
-  This stops the progress spinner to be displayed
+  Show a progress spinner as long as the pilot provisions
 
 %ignore_sync_error
 

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -223,7 +223,7 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
     // Setup VM...
     let pilot_options = Lookup::get_pilot_run_options();
     let mut spinner = None;
-    if ! pilot_options.contains_key("%silent") {
+    if pilot_options.contains_key("%progress") {
         spinner = Some(
             Spinner::new_with_stream(
                 spinners::Line, "Launching flake...",

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -281,7 +281,7 @@ pub fn create(
     }
     let pilot_options = Lookup::get_pilot_run_options();
     let mut spinner = None;
-    if ! pilot_options.contains_key("%silent") {
+    if pilot_options.contains_key("%progress") {
         spinner = Some(
             Spinner::new_with_stream(
                 spinners::Line, "Launching flake...",


### PR DESCRIPTION
So far the user had to pass `%silent` to the call to make the pilot stop showing progress information. The default behavior to show progress information caused a lot of confusion and breakage to script code calling an application as a flake. It is rather unexpected that such progress information is provided by default. This commit reverse the logic such that a user has to provide `%progress` to see the progress spinner while the pilot is working.

This Fixes #80