### PR TITLE
Refactor code to fix certain security issues

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -16,6 +16,7 @@ lazy_static = { version = "1.4" }
 uzers = { version = "0.12" }
 rust-ini = { version = "0.21" }
 tempfile = { version = "3.4" }
+libc = { version = "0.2" }
 
 [features]
 json = ["serde_json"]

--- a/common/src/io.rs
+++ b/common/src/io.rs
@@ -21,9 +21,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
+use std::fs::{self, DirBuilder, File, OpenOptions};
+use std::io::ErrorKind;
+use std::os::unix::fs::{
+    DirBuilderExt, MetadataExt, OpenOptionsExt, PermissionsExt
+};
+use std::path::Path;
+
+use uzers::get_current_uid;
+
 use crate::flakelog::FlakeLog;
 use crate::error::FlakeError;
-use crate::user::User;
+use crate::user::{User, mkdir};
 use crate::command::CommandExtTrait;
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -31,6 +40,103 @@ pub struct IO {
 }
 
 impl IO {
+    pub fn private_dir(base: &str, user: User) -> Result<String, FlakeError> {
+        /*!
+        Provide a private directory for the calling user below base
+
+        Meta data like container/VM ID files or communication sockets
+        must not be writable by other users. As the base directory is
+        shared between all users of the system it is created with the
+        sticky bit set, like /tmp. The per user directory below it is
+        created with 0700 permissions and is required to be owned by
+        the calling user.
+        !*/
+        if ! Path::new(base).exists() {
+            mkdir(base, "1777", user)?;
+        }
+        let base_attributes = fs::symlink_metadata(base)?;
+        if ! base_attributes.is_dir() {
+            return Err(FlakeError::IOError {
+                kind: "Insecure meta data directory".to_string(),
+                message: format!("{base} is not a directory")
+            })
+        }
+        let base_mode = base_attributes.permissions().mode();
+        if base_mode & 0o002 != 0 && base_mode & 0o1000 == 0 {
+            // A directory which everybody can write to allows to
+            // delete and replace the meta data of other users unless
+            // the sticky bit restricts this to the file owner
+            return Err(FlakeError::IOError {
+                kind: "Insecure meta data directory".to_string(),
+                message: format!(
+                    "{base} is world writable without the sticky bit set. \
+                    Please fix this with: chmod 1777 {base}"
+                )
+            })
+        }
+        let private_dir = format!("{}/{}", base, get_current_uid());
+        if let Err(error) = DirBuilder::new().mode(0o700).create(&private_dir) {
+            if error.kind() != ErrorKind::AlreadyExists {
+                return Err(FlakeError::IO(error))
+            }
+        }
+        let attributes = fs::symlink_metadata(&private_dir)?;
+        if ! attributes.is_dir() || attributes.uid() != get_current_uid() {
+            return Err(FlakeError::IOError {
+                kind: "Insecure meta data directory".to_string(),
+                message: format!(
+                    "{private_dir} is not a directory owned by the caller"
+                )
+            })
+        }
+        if attributes.permissions().mode() & 0o077 != 0 {
+            fs::set_permissions(
+                &private_dir, fs::Permissions::from_mode(0o700)
+            )?;
+        }
+        Ok(private_dir)
+    }
+
+    pub fn no_symlink(path: &str) -> Result<(), FlakeError> {
+        /*!
+        Make sure the given meta data path is not a symbolic link
+
+        Meta data files are stored below directories which are also
+        used by other users. Following a link placed there by someone
+        else would cause reads and writes to an unexpected target
+        !*/
+        if let Ok(attributes) = fs::symlink_metadata(path) {
+            if attributes.file_type().is_symlink() {
+                return Err(FlakeError::IOError {
+                    kind: "Insecure meta data file".to_string(),
+                    message: format!(
+                        "{path} is a symbolic link, refusing to use it"
+                    )
+                })
+            }
+        }
+        Ok(())
+    }
+
+    pub fn create_meta_file(path: &str) -> Result<File, FlakeError> {
+        /*!
+        Create/Truncate the given meta data file
+
+        The file is opened with O_NOFOLLOW to never write through a
+        symbolic link somebody else could have placed at that path
+        !*/
+        Self::no_symlink(path)?;
+        Ok(
+            OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .custom_flags(libc::O_NOFOLLOW)
+                .open(path)?
+        )
+    }
+
     pub fn sync_includes(
         target: &String, tar_includes: Vec<&str>, path_includes: Vec<&str>, user: User
     ) -> Result<(), FlakeError> {

--- a/common/src/lookup.rs
+++ b/common/src/lookup.rs
@@ -64,6 +64,22 @@ impl Lookup {
         run
     }
 
+    pub fn is_safe_instance_name(name: &str) -> bool {
+        /*!
+        Check the given @NAME pilot argument
+
+        The instance name becomes part of file names, socket names
+        and network device names. Therefore only characters which
+        are safe to be used in these names are allowed
+        !*/
+        if name.is_empty() || name.len() > 64 || ! name.starts_with('@') {
+            return false
+        }
+        name.chars().all(
+            |c| c.is_ascii_alphanumeric() || matches!(c, '@' | '=' | '_' | '-')
+        )
+    }
+
     pub fn get_pilot_run_options() -> HashMap<String, String> {
         /*!
         read runtime options which are only meant to be used for the

--- a/common/src/user.rs
+++ b/common/src/user.rs
@@ -61,8 +61,29 @@ impl User<'_> {
     }
 
     pub fn run<S: AsRef<OsStr>>(&self, command: S) -> Command {
+        /*!
+        Call command via sudo
+
+        The environment of the caller is not passed along. Handing
+        the environment of an unprivileged caller to a program
+        running as root allows to influence that program in ways
+        the sudo rule for it never intended
+        !*/
+        self.run_with_env(command, &[])
+    }
+
+    pub fn run_with_env<S: AsRef<OsStr>>(
+        &self, command: S, keep_env: &[&str]
+    ) -> Command {
+        /*!
+        Call command via sudo, preserving the given environment
+        variables. Only variables the called program really needs
+        should be listed here
+        !*/
         let mut c = Command::new("sudo");
-        c.arg("--preserve-env");
+        if ! keep_env.is_empty() {
+            c.arg(format!("--preserve-env={}", keep_env.join(",")));
+        }
         if let Some(name) = self.name {
             c.arg("--user").arg(name);
         }

--- a/doc/flake-ctl-firecracker-pull.rst
+++ b/doc/flake-ctl-firecracker-pull.rst
@@ -74,6 +74,18 @@ OPTIONS
 
   Single rootfs image to pull into local image store
 
+ENVIRONMENT
+-----------
+
+FLAKE_ALLOW_INSECURE_TRANSPORT
+
+  The images pulled here provide the root filesystem and the kernel
+  of a virtual machine. They are therefore only fetched via https.
+  If the image can only be reached through a transport that provides
+  no integrity and no authenticity of the server, e.g plain http,
+  setting this variable allows to use it. Only do this if the
+  connection to the image source can be trusted.
+
 EXAMPLE
 -------
 

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -36,10 +36,12 @@ pub const OVERLAY_WORK: &str =
     "overlayroot/rootfs_work";
 pub const FIRECRACKER_OVERLAY_DIR:&str =
     ".config/flakes/firecracker/storage";
+pub const FIRECRACKER_STORAGE_DIR:&str =
+    "storage";
 pub const FIRECRACKER_TEMPLATE:&str =
     "/etc/flakes/firecracker.json";
 pub const FIRECRACKER_VSOCK_PREFIX: &str =
-    "/tmp/sci_cmd_";
+    "sci_cmd_";
 pub const FIRECRACKER_VSOCK_PORT_START: u32 = 49200;
 pub const GC_THRESHOLD: usize = 20;
 pub const VM_CID: u32 = 3;

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -36,6 +36,8 @@ use std::path::Path;
 use std::process::{Stdio, id};
 use std::env;
 use std::fs;
+use std::fs::DirBuilder;
+use std::os::unix::fs::DirBuilderExt;
 use crate::config::{config, RuntimeSection, EngineSection};
 use tempfile::{NamedTempFile, tempdir};
 use std::io::{self, Write, SeekFrom, Seek};
@@ -182,9 +184,30 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
             )
         })
     }
+    // Read and check optional @NAME pilot arguments. The instance
+    // name is used to construct file, socket and network device
+    // names and is therefore only allowed to contain characters
+    // which are safe to be used in such names
+    for instance_name in env::args().skip(1).filter(
+        |arg| arg.starts_with('@')
+    ) {
+        if ! Lookup::is_safe_instance_name(&instance_name) {
+            return Err(FlakeError::IOError {
+                kind: "Invalid instance name".to_string(),
+                message: format!(
+                    "The instance name {instance_name} contains characters \
+                    which are not allowed"
+                )
+            })
+        }
+    }
+
+    // Make sure meta dirs exists
+    init_meta_dirs()?;
+
     // setup VM ID file name
     let vm_id_file_path = get_meta_file_name(
-        program_name, &get_firecracker_ids_dir(false), "vmid"
+        program_name, &get_ids_dir()?, "vmid"
     );
 
     // get flake config sections
@@ -196,9 +219,6 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
     let tar_includes = config().tars();
     let path_includes = config().paths();
     let has_includes = !tar_includes.is_empty() || !path_includes.is_empty();
-
-    // Make sure meta dirs exists
-    init_meta_dirs()?;
 
     // Check early return condition
     if Path::new(&vm_id_file_path).exists() && gc_meta_files(
@@ -259,17 +279,12 @@ fn run_creation(
     has_includes: bool
 ) -> Result<(String, String), FlakeError> {
     // Create initial vm_id_file with process ID set to 0
-    std::fs::File::create(vm_id_file_path)?.write_all("0".as_bytes())?;
+    IO::create_meta_file(vm_id_file_path)?.write_all("0".as_bytes())?;
     let result = ("0".to_owned(), vm_id_file_path.to_owned());
 
     // Setup root overlay if configured
     let vm_overlay_file = get_meta_file_name(
-        program_name,
-        &format!("{}/{}",
-            env::var("HOME").unwrap_or("/tmp".to_string()),
-            defaults::FIRECRACKER_OVERLAY_DIR
-        ),
-        "ext2"
+        program_name, &get_overlay_dir()?, "ext2"
     );
     if let Some(overlay_size) = engine_section.overlay_size {
         let overlay_size = overlay_size.parse::<ByteUnit>().expect(
@@ -371,7 +386,7 @@ pub fn start(
 }
 
 pub fn call_instance(
-    config_file: &NamedTempFile, vm_id_file: &String, is_blocking: bool
+    config_file: &NamedTempFile, vm_id_file: &str, is_blocking: bool
 ) -> Result<(), FlakeError> {
     /*!
     Run firecracker with specified configuration
@@ -397,7 +412,7 @@ pub fn call_instance(
     if Lookup::is_debug() {
         debug!("PID {pid}")
     }
-    File::create(vm_id_file)?.write_all(pid.to_string().as_bytes())?;
+    IO::create_meta_file(vm_id_file)?.write_all(pid.to_string().as_bytes())?;
     if is_blocking {
         handle_output(child.wait_with_output(), firecracker.get_args())?;
     }
@@ -428,12 +443,10 @@ pub fn check_connected(program_name: &String) -> Result<(), FlakeError> {
     Check if instance connection is OK
     !*/
     let mut retry_count = 0;
-    let vsock_uds_path = format!(
-        "{}{}.sock",
-        defaults::FIRECRACKER_VSOCK_PREFIX,
-        get_meta_name(program_name)
-    );
-    chmod(&vsock_uds_path, "777", User::ROOT)?;
+    let vsock_uds_path = get_vsock_uds_path(program_name)?;
+    // The socket provides command execution inside of the VM.
+    // Only the owner of the VM instance is allowed to talk to it
+    chmod(&vsock_uds_path, "600", User::ROOT)?;
     loop {
         if retry_count == defaults::RETRIES {
             if Lookup::is_debug() {
@@ -477,7 +490,9 @@ pub fn check_connected(program_name: &String) -> Result<(), FlakeError> {
     }
 }
 
-pub fn send_command_to_instance(program_name: &String, exec_port: u32) -> i32 {
+pub fn send_command_to_instance(
+    program_name: &str, vsock_uds_path: &str, exec_port: u32
+) -> i32 {
     /*!
     Send command to the VM via a vsock
     !*/
@@ -486,11 +501,6 @@ pub fn send_command_to_instance(program_name: &String, exec_port: u32) -> i32 {
     let mut run: Vec<String> = vec![get_target_app_path(program_name)];
 
     run = Lookup::get_run_cmdline(run, false);
-    let vsock_uds_path = format!(
-        "{}{}.sock",
-        defaults::FIRECRACKER_VSOCK_PREFIX,
-        get_meta_name(program_name)
-    );
     loop {
         status_code = 1;
         if retry_count == defaults::RETRIES {
@@ -499,7 +509,7 @@ pub fn send_command_to_instance(program_name: &String, exec_port: u32) -> i32 {
             }
             return status_code
         }
-        match UnixStream::connect(&vsock_uds_path) {
+        match UnixStream::connect(vsock_uds_path) {
             Ok(mut stream) => {
                 stream.write_all(
                     format!("CONNECT {}\n", defaults::VM_PORT).as_bytes()
@@ -556,10 +566,7 @@ pub fn execute_command_at_instance(
     Send command to a vsock connected to a running instance
     !*/
     let mut retry_count = 0;
-    let vsock_uds_path = format!(
-        "{}{}.sock",
-        defaults::FIRECRACKER_VSOCK_PREFIX, get_meta_name(program_name)
-    );
+    let vsock_uds_path = get_vsock_uds_path(program_name)?;
 
     // wait for UDS socket to appear
     loop {
@@ -588,9 +595,10 @@ pub fn execute_command_at_instance(
     // spawn the listener and wait for sci to run the command
     let exec_port = get_exec_port();
     let command_socket = &format!("{vsock_uds_path}_{exec_port}");
+    IO::no_symlink(command_socket)?;
     let thread_handle = stream_listener(command_socket);
 
-    send_command_to_instance(program_name, exec_port);
+    send_command_to_instance(program_name, &vsock_uds_path, exec_port);
 
     let _ = thread_handle.join();
     Ok(())
@@ -672,12 +680,7 @@ pub fn create_firecracker_config(
     // set drive section for overlay
     if engine_section.overlay_size.is_some() {
         let vm_overlay_file = get_meta_file_name(
-            program_name,
-            &format!("{}/{}",
-                env::var("HOME").unwrap_or("/tmp".to_string()),
-                defaults::FIRECRACKER_OVERLAY_DIR
-            ),
-            "ext2"
+            program_name, &get_overlay_dir()?, "ext2"
         );
 
         let cache_type =
@@ -726,11 +729,7 @@ pub fn create_firecracker_config(
 
     // set vsock name
     firecracker_config.vsock.guest_cid = defaults::VM_CID;
-    firecracker_config.vsock.uds_path = format!(
-        "{}{}.sock",
-        defaults::FIRECRACKER_VSOCK_PREFIX,
-        get_meta_name(program_name)
-    );
+    firecracker_config.vsock.uds_path = get_vsock_uds_path(program_name)?;
 
     // set mem_size_mib
     if let Some(mem_size_mib) = engine_section.mem_size_mib {
@@ -763,16 +762,65 @@ pub fn get_target_app_path(program_name: &str) -> String {
 
 }
 
-pub fn init_meta_dirs() -> Result<(), CommandError> {
-    [
-        &format!("{}/{}",
-            env::var("HOME").unwrap_or("/tmp".to_string()),
-            defaults::FIRECRACKER_OVERLAY_DIR
+pub fn get_ids_dir() -> Result<String, FlakeError> {
+    /*!
+    Provide the private directory of the calling user to store
+    the VM ID files and the sockets to talk to the VM instances
+    !*/
+    IO::private_dir(&get_firecracker_ids_dir(false), User::ROOT)
+}
+
+pub fn get_overlay_dir() -> Result<String, FlakeError> {
+    /*!
+    Provide the directory to store the VM overlay images
+
+    The overlay images are stored in the home directory of the
+    calling user. If there is no home directory the private
+    meta data directory of the user is used. A directory shared
+    with other users must not be used because the overlay image
+    becomes the root filesystem of the VM
+    !*/
+    match env::var("HOME") {
+        Ok(home) => Ok(
+            format!("{}/{}", home, defaults::FIRECRACKER_OVERLAY_DIR)
         ),
-        &get_firecracker_ids_dir(false)
-    ].iter()
-        .filter(|path| !Path::new(path).is_dir())
-        .try_for_each(|path| mkdir(path, "777", User::ROOT))
+        Err(_) => Ok(
+            format!("{}/{}", get_ids_dir()?, defaults::FIRECRACKER_STORAGE_DIR)
+        )
+    }
+}
+
+pub fn get_vsock_uds_path(program_name: &String) -> Result<String, FlakeError> {
+    /*!
+    Provide the path of the socket used to talk to the VM instance
+
+    The socket allows to run commands inside of the VM and is
+    therefore placed in the private directory of the calling user
+    !*/
+    Ok(format!(
+        "{}/{}{}.sock",
+        get_ids_dir()?,
+        defaults::FIRECRACKER_VSOCK_PREFIX,
+        get_meta_name(program_name)
+    ))
+}
+
+pub fn init_meta_dirs() -> Result<(), FlakeError> {
+    /*!
+    Create meta data directory structure
+
+    The directories are created for and owned by the calling user.
+    Meta data of one user must not be modifiable by another user
+    !*/
+    get_ids_dir()?;
+    let overlay_dir = get_overlay_dir()?;
+    if ! Path::new(&overlay_dir).is_dir() {
+        DirBuilder::new()
+            .recursive(true)
+            .mode(0o700)
+            .create(&overlay_dir)?;
+    }
+    Ok(())
 }
 
 pub fn vm_running(vmid: &String) -> Result<bool, FlakeError> {
@@ -846,11 +894,7 @@ pub fn gc_meta_files(
                         error!("Failed to remove VMID: {error:?}")
                     }
                 }
-                let vsock_uds_path = format!(
-                    "{}{}.sock",
-                    defaults::FIRECRACKER_VSOCK_PREFIX,
-                    get_meta_name(program_name)
-                );
+                let vsock_uds_path = get_vsock_uds_path(program_name)?;
                 if Path::new(&vsock_uds_path).exists() {
                     if Lookup::is_debug() {
                         debug!("Deleting {vsock_uds_path}");
@@ -859,10 +903,7 @@ pub fn gc_meta_files(
                 }
                 let vm_overlay_file = format!(
                     "{}/{}",
-                    &format!("{}/{}",
-                        env::var("HOME").unwrap_or("/tmp".to_string()),
-                        defaults::FIRECRACKER_OVERLAY_DIR
-                    ),
+                    get_overlay_dir()?,
                     Path::new(&vm_id_file)
                         .file_name()
                         .and_then(OsStr::to_str)
@@ -895,7 +936,7 @@ pub fn gc(program_name: &String) -> Result<(), FlakeError> {
     /*!
     Garbage collect VMID files for which no VM exists anymore
     !*/
-    let vmid_file_names: Vec<_> = fs::read_dir(get_firecracker_ids_dir(false))?
+    let vmid_file_names: Vec<_> = fs::read_dir(get_ids_dir()?)?
         .filter_map(|entry| entry.ok())
         .filter_map(|x| x.path()
             .to_str()
@@ -918,14 +959,15 @@ pub fn gc(program_name: &String) -> Result<(), FlakeError> {
 
 pub fn delete_file(filename: &String) -> bool {
     /*!
-    Delete file via sudo
+    Delete file
+
+    The deletion is done in process. Calling out to rm would
+    resolve the program through the callers PATH
     !*/
-    let mut call = Command::new("rm");
-    call.arg("-f").arg(filename);
-    match call.status() {
+    match fs::remove_file(filename) {
         Ok(_) => { },
         Err(error) => {
-            error!("Failed to rm: {filename}: {error:?}");
+            error!("Failed to remove: {filename}: {error:?}");
             return false
         }
     }

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -42,6 +42,8 @@ pub const FIRECRACKER_KERNEL_NAME:&str =
     "kernel";
 pub const FIRECRACKER_ROOTFS_NAME:&str =
     "rootfs";
+pub const FIRECRACKER_CHECKSUM_NAME:&str =
+    "checksum";
 pub const FIRECRACKER_SCI:&str =
     "/usr/lib/flake-pilot/sci";
 pub const PODMAN_ENGINE:&str =
@@ -54,3 +56,5 @@ pub const FLAKE_LIST_COLUMN_SPACING:&str =
     "  ";
 pub const FLAKE_LIST_NO_VALUE:&str =
     "-";
+pub const SHA256_TOOL:&str =
+    "sha256sum";

--- a/flake-ctl/src/fetch.rs
+++ b/flake-ctl/src/fetch.rs
@@ -20,6 +20,7 @@
 //
 use std::io::{Error, ErrorKind};
 use std::cmp::min;
+use std::env;
 use std::fs::File;
 use std::io::Write;
 use indicatif::{ProgressBar, ProgressStyle};
@@ -76,8 +77,28 @@ pub async fn send_request(
 ) -> Result<reqwest::Response, Box<dyn std::error::Error>> {
     /*!
     Send GET request to the specified url and return response object
+
+    The data fetched here becomes the rootfs and the kernel of a
+    VM. Downloading it over a transport that provides no integrity
+    and no authenticity of the server allows an attacker on the
+    network path to replace it. Therefore only https is used unless
+    the caller explicitly asks for something else by setting the
+    FLAKE_ALLOW_INSECURE_TRANSPORT environment variable
     !*/
+    let allow_insecure = env::var("FLAKE_ALLOW_INSECURE_TRANSPORT").is_ok();
+    if ! allow_insecure && ! url.starts_with("https://") {
+        return Err(
+            Box::new(Error::new(ErrorKind::InvalidInput, format!(
+                "Refusing to fetch '{url}' over an insecure transport. \
+                Use an https URL or set FLAKE_ALLOW_INSECURE_TRANSPORT \
+                if the source can be trusted"
+            )))
+        )
+    }
     let client = reqwest::Client::builder()
+        // also applies to redirects, an https URL must not be
+        // redirected to a plain http location
+        .https_only(! allow_insecure)
         .build()?;
 
     let response = client

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -24,12 +24,14 @@
 //
 use flakes::config::get_flakes_dir;
 use std::ffi::OsStr;
+use std::io::{self, Read};
 use std::os::unix::fs::PermissionsExt;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use tempfile::tempdir;
 use std::path::Path;
 use std::borrow::Cow;
 use std::fs;
+use std::fs::File;
 
 use crate::defaults;
 use crate::{app, app_config};
@@ -64,12 +66,15 @@ pub fn init_toplevel_image_dir(registry_dir: &str) -> bool {
                 match fs::metadata(&subdir) {
                     Ok(attr) => {
                         let mut permissions = attr.permissions();
-                        permissions.set_mode(0o777);
+                        // The images in this directory are the root
+                        // filesystem and the kernel of a VM. They must
+                        // not be modifiable by everybody
+                        permissions.set_mode(0o755);
                         match fs::set_permissions(&subdir, permissions) {
                             Ok(_) => { },
                             Err(error) => {
                                 error!(
-                                    "Failed to set 0o777 bits: {} {}",
+                                    "Failed to set 0o755 bits: {} {}",
                                     subdir, error
                                 );
                                 ok = false
@@ -314,13 +319,18 @@ pub async fn pull_kis_image(
                     return result
                 }
             }
-            let mut kis_ok = 4;
+            let mut kis_ok = 3;
             for path in fs::read_dir(&work_dir).unwrap() {
                 let path = path.unwrap().path();
                 let extension = path.extension().unwrap();
-                if extension == OsStr::new("append") || extension == OsStr::new("md5") {
-                    fs::remove_file(&path).unwrap();
+                if extension == OsStr::new("sha256") {
+                    fs::rename(&path, format!("{}/{}",
+                        work_dir, defaults::FIRECRACKER_CHECKSUM_NAME
+                    )).unwrap();
                     kis_ok -= 1;
+                } else if extension == OsStr::new("append") {
+                    fs::remove_file(&path).unwrap();
+                    // unused
                 } else if extension == OsStr::new("initrd") {
                     fs::rename(&path, format!("{}/{}",
                         work_dir, defaults::FIRECRACKER_INITRD_NAME
@@ -343,6 +353,20 @@ pub async fn pull_kis_image(
                 return result
             }
 
+            // Verify the rootfs image against the checksum record
+            // that came with the archive
+            info!("Verifying image checksum...");
+            let image_checksum = fs::read_to_string(
+                format!("{}/{}", work_dir, defaults::FIRECRACKER_CHECKSUM_NAME)
+            ).unwrap_or_default().trim().to_string();
+            if ! verify_checksum(
+                &format!("{}/{}", work_dir, defaults::FIRECRACKER_ROOTFS_NAME),
+                &image_checksum
+            ) {
+                error!("Image checksum verification failed");
+                return result
+            }
+
             // Move to final firecracker image store
             if ! mv(&work_dir, &image_dir, "root") {
                 return result
@@ -354,6 +378,110 @@ pub async fn pull_kis_image(
         }
     }
     result
+}
+
+pub fn verify_checksum(image: &str, checksum_record: &str) -> bool {
+    /*!
+    Verify the given image against the sha256 checksum record
+    shipped inside of the KIS archive
+
+    The record is created by kiwi and has the format:
+
+        <sha256> <blocks> <blocksize>
+
+    A record which cannot be read or a missing checksum program
+    is reported but does not fail the operation. A checksum
+    which does not match the image does
+    !*/
+    let mut record = checksum_record.split_whitespace();
+    let expected_sum = match record.next() {
+        Some(expected_sum) => expected_sum,
+        None => {
+            warn!("No checksum record found, skipping verification");
+            return true
+        }
+    };
+    // If the record provides a block count the checksum was
+    // created over that amount of data and not over the
+    // complete file
+    let size = match (record.next(), record.next()) {
+        (Some(blocks), Some(blocksize)) => {
+            match (blocks.parse::<u64>(), blocksize.parse::<u64>()) {
+                (Ok(blocks), Ok(blocksize)) => Some(blocks * blocksize),
+                _ => None
+            }
+        },
+        _ => None
+    };
+    match checksum(image, size) {
+        Some(image_sum) => {
+            if image_sum != expected_sum {
+                error!(
+                    "Checksum mismatch for {image}: \
+                    expected {expected_sum}, got {image_sum}"
+                );
+                return false
+            }
+        },
+        None => {
+            warn!("Could not calculate checksum, skipping verification");
+        }
+    }
+    true
+}
+
+fn checksum(image: &str, size: Option<u64>) -> Option<String> {
+    /*!
+    Calculate the sha256 sum of the first size bytes of image.
+    If no size is given the complete file is read
+    !*/
+    let tool = defaults::SHA256_TOOL;
+    let file = match File::open(image) {
+        Ok(file) => file,
+        Err(error) => {
+            error!("Failed to open {image}: {error:?}");
+            return None
+        }
+    };
+    let mut reader: Box<dyn Read> = match size {
+        Some(size) => Box::new(file.take(size)),
+        None => Box::new(file)
+    };
+    let mut call = match Command::new(tool)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn()
+    {
+        Ok(call) => call,
+        Err(error) => {
+            error!("Failed to execute {tool}: {error:?}");
+            return None
+        }
+    };
+
+    {
+        let mut stdin = call.stdin.take()?;
+        if let Err(error) = io::copy(&mut reader, &mut stdin) {
+            error!("Failed to send {image} to {tool}: {error:?}");
+            // the pipe is closed by the drop of stdin below,
+            // this lets the checksum tool terminate
+        }
+    }
+
+    match call.wait_with_output() {
+        Ok(output) => {
+            if ! output.status.success() {
+                error!("{tool} failed: {:?}", output.status);
+                return None
+            }
+            String::from_utf8_lossy(&output.stdout)
+                .split_whitespace().next().map(ToOwned::to_owned)
+        },
+        Err(error) => {
+            error!("Failed to read {tool} output: {error:?}");
+            None
+        }
+    }
 }
 
 pub fn mkdir(dirname: &String, user: &str) -> bool {

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -46,7 +46,9 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
 
     let args = cli::parse_args();
 
-    mkdir(&get_flakes_dir(false), "777", User::ROOT)?;
+    // The flake registry is read by the pilots to learn how to run
+    // an application. It is therefore only writable by root
+    mkdir(&get_flakes_dir(false), "755", User::ROOT)?;
 
     match &args.command {
         // list

--- a/flake-ctl/src/podman.rs
+++ b/flake-ctl/src/podman.rs
@@ -275,7 +275,14 @@ pub fn setup_podman_call(usermode: bool) -> Command {
     env::set_var("CONTAINERS_STORAGE_CONF", get_podman_storage_conf(usermode));
     env::set_var("XDG_RUNTIME_DIR", &container_runroot);
     let mut call = Command::new("sudo");
-    call.arg("--preserve-env");
+    // Only the variables set above are handed over to the podman
+    // call. Passing the complete environment of the caller to a
+    // process running as root allows to influence that process in
+    // ways the sudo rule for it never intended
+    call.arg(format!(
+        "--preserve-env={}",
+        ["CONTAINERS_STORAGE_CONF", "XDG_RUNTIME_DIR"].join(",")
+    ));
     if usermode {
         call.arg("--user").arg(calling_user_name);
     }

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -173,6 +173,13 @@ install -m 644 flakes.yml %{buildroot}/etc/flakes.yml
 %doc /usr/share/man/man8/flake-ctl.8.gz
 %doc /usr/share/man/man8/flake-ctl-list.8.gz
 
+%post
+if [ -d /tmp/flakes ];then
+    # make sure to move an eventually existing
+    # tmp flakes dir to sticky bit permissions
+    chmod 1777 /tmp/flakes
+fi
+
 %files -n flake-pilot-podman
 %config /etc/flakes/container-flake.yaml
 %config /etc/flakes/storage.conf

--- a/podman-pilot/src/defaults.rs
+++ b/podman-pilot/src/defaults.rs
@@ -23,6 +23,7 @@
 // SOFTWARE.
 //
 pub const GC_THRESHOLD: i32 = 20;
+pub const VAR_EXPANSION_LIMIT: i32 = 10;
 pub const HOST_DEPENDENCIES: &str = "removed";
 pub const SYSTEM_HOST_DEPENDENCIES: &str = "systemfiles";
 pub const PODMAN_PATH: &str = "/usr/bin/podman";

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -137,6 +137,17 @@ pub fn create(
     // https://rust-random.github.io/book/guide-seeding.html#fresh-entropy
     let (name_value, _): (Vec<_>, Vec<_>) = env::args()
         .skip(1).partition(|arg| arg.starts_with('@'));
+    for instance_name in &name_value {
+        if ! Lookup::is_safe_instance_name(instance_name) {
+            return Err(FlakeError::IOError {
+                kind: "Invalid instance name".to_string(),
+                message: format!(
+                    "The instance name {instance_name} contains characters \
+                    which are not allowed"
+                )
+            })
+        }
+    }
     let name = name_value.first().map(String::as_str).unwrap_or("");
     let suffix = if name.is_empty() && ! (resume || attach) {
         let mut rng = ChaCha20Rng::from_os_rng();
@@ -173,32 +184,33 @@ pub fn create(
         root.status()?;
     }
 
-    let container_cid_file = format!(
-        "{}/{}{}_{}.cid",
-        get_podman_ids_dir(usermode), program_name, suffix,
-        calling_user_name.to_str().unwrap()
-    );
-
     // read podman storage setup
     let storage = read_storage_conf(usermode)?;
 
     // create storage paths
-    mkdir(storage.get("graphroot").unwrap(), "777", user)?;
+    mkdir(storage.get("graphroot").unwrap(), "755", user)?;
     let container_runroot = format!(
         "{}/{}",
         storage.get("runroot").unwrap(),
         calling_user_name.to_str().unwrap()
     );
-    mkdir(&container_runroot, "777", user)?;
+    mkdir(&container_runroot, "700", user)?;
+
+    // Make sure CID dir exists
+    let container_ids_dir = init_cid_dir(user)?;
+
+    let container_cid_file = format!(
+        "{}/{}{}_{}.cid",
+        container_ids_dir, program_name, suffix,
+        calling_user_name.to_str().unwrap()
+    );
+    IO::no_symlink(&container_cid_file)?;
 
     // init podman creation call
     let mut app = setup_podman_call(usermode);
     app.arg("create")
         .arg("--pull=newer")
         .arg("--cidfile").arg(&container_cid_file);
-
-    // Make sure CID dir exists
-    init_cid_dir(user)?;
 
     // Check early return condition in resume mode
     if Path::new(&container_cid_file).exists() &&
@@ -216,7 +228,21 @@ pub fn create(
     let var_pattern = Regex::new(r"%([A-Z]+)").unwrap();
     for arg in podman.iter().flatten().flat_map(|x| x.splitn(2, ' ')) {
         let mut arg_value = arg.to_string();
+        // The value of a variable can contain another %VAR reference.
+        // Expansion is therefore done repeatedly but only up to a
+        // fixed limit. Without it a variable value referencing itself
+        // would keep this loop running forever
+        let mut expansion_count = 0;
         while var_pattern.captures(&arg_value.clone()).is_some() {
+            expansion_count += 1;
+            if expansion_count > defaults::VAR_EXPANSION_LIMIT {
+                return Err(FlakeError::IOError {
+                    kind: "Invalid runtime option".to_string(),
+                    message: format!(
+                        "Too many variable expansions in: {arg}"
+                    )
+                })
+            }
             for capture in var_pattern.captures_iter(&arg_value.clone()) {
                 // replace %VAR placeholder(s) with the respective
                 // environment variable value if possible.
@@ -695,15 +721,13 @@ pub fn sync_host(
     Ok(())
 }
 
-pub fn init_cid_dir(user: User) -> Result<(), FlakeError> {
+pub fn init_cid_dir(user: User) -> Result<String, FlakeError> {
     /*!
-    Create meta data directory structure
+    Create meta data directory structure and return the private
+    directory of the calling user to store the CID files in
     !*/
     let usermode = user.get_name() != "root";
-    if ! Path::new(&get_podman_ids_dir(usermode)).is_dir() {
-        mkdir(&get_podman_ids_dir(usermode), "777", user)?;
-    }
-    Ok(())
+    IO::private_dir(&get_podman_ids_dir(usermode), user)
 }
 
 pub fn container_exists(cid: &str) -> Result<bool, FlakeError> {
@@ -841,6 +865,11 @@ pub fn build_system_dependencies(
     Check if container provides a /systemfiles script which
     contains code to build up a list of files that needs
     to be provisioned from the host
+
+    Note: The script is part of the container and is called
+    with the privileges needed to provision the container.
+    Registering a delta container therefore means to trust
+    the code that comes with it
     !*/
     let system_deps = format!("{}/{}", target, dependency_file);
     if exists(&system_deps, User::ROOT)? {
@@ -918,6 +947,7 @@ pub fn gc_cid_file(container_cid_file: &String) -> Result<bool, FlakeError> {
     if no longer present. Return a true value if the container
     exists, in any other case return false.
     !*/
+    IO::no_symlink(container_cid_file)?;
     let cid = fs::read_to_string(container_cid_file)?;
 
     if container_exists(&cid)? {
@@ -936,14 +966,14 @@ pub fn gc(user: User) -> Result<(), FlakeError> {
     let mut cid_file_names: Vec<String> = Vec::new();
     let mut cid_file_count: i32 = 0;
     let paths;
-    let usermode = user.get_name() != "root";
-    match fs::read_dir(get_podman_ids_dir(usermode)) {
+    let container_ids_dir = init_cid_dir(user)?;
+    match fs::read_dir(&container_ids_dir) {
         Ok(result) => { paths = result },
         Err(error) => {
             return Err(FlakeError::IOError {
                 kind: format!("{:?}", error.kind()),
                 message: format!("fs::read_dir failed on {}: {}",
-                    get_podman_ids_dir(usermode), error
+                    container_ids_dir, error
                 )
             })
         }
@@ -972,7 +1002,14 @@ pub fn setup_podman_call(usermode: bool) -> Command {
     env::set_var("CONTAINERS_STORAGE_CONF", get_podman_storage_conf(usermode));
     env::set_var("XDG_RUNTIME_DIR", &container_runroot);
     let mut call = Command::new("sudo");
-    call.arg("--preserve-env");
+    // Only the variables set above are handed over to the podman
+    // call. Passing the complete environment of the caller to a
+    // process running as root allows to influence that process in
+    // ways the sudo rule for it never intended
+    call.arg(format!(
+        "--preserve-env={}",
+        ["CONTAINERS_STORAGE_CONF", "XDG_RUNTIME_DIR"].join(",")
+    ));
     if usermode {
         call.arg("--user").arg(calling_user_name);
     } else {


### PR DESCRIPTION
**New shared primitives**
  IO::private_dir(base, user) — creates the shared base dir as 1777 (sticky) and a per-uid 0700 subdir, verifying it is a real directory owned by the caller. Refuses to run if the base is world-writable without the sticky bit. IO::no_symlink(path) /  IO::create_meta_file(path) — O_NOFOLLOW, mode 0600.

**podman-pilot**
  @NAME validated before use; graphroot 777→755, per-user  runroot 777→700; CID files moved into the private per-uid dir  with a symlink check on read and on create; gc()/gc_cid_file()  follow; sudo --preserve-env moved to --preserve-env=CONTAINERS_STORAGE_CONF,XDG_RUNTIME_DIR;  the %VAR expansion loop is bounded (defaults::VAR_EXPANSION_LIMIT).

**firecracker-pilot**
  @NAME validated; .vmid files in the private per-uid dir, written via IO::create_meta_file; the sci command socket moved from `/tmp/sci_cmd_<app>.sock` to `<ids-dir>/<uid>/sci_cmd_<app>.sock` and chmod 777→600 (the per-port listener socket inherits the private dir and gets a symlink check); overlay dir created by the calling user at 0700 — when HOME is unset it now falls back to the user's private dir instead of shared /tmp; delete_file uses fs::remove_file instead of a PATH-resolved rm.

**flake-ctl**
  /usr/share/flakes 777→755;  /var/lib/firecracker/{images,storage} 0o777→0o755;  --preserve-env scoped as in the pilot; downloads are refused over  non-https unless FLAKE_ALLOW_INSECURE_TRANSPORT is set (https_only
  also blocks https→http redirects); the KIS .sha256 record is now  verified against the rootfs instead of being deleted unread,  documented in doc/flake-ctl-firecracker-pull.rst.

**Behaviour changes:**

1. Env inheritance is gone. Flakes that relied on arbitrary variables reaching podman or the sudo-wrapped helpers will no longer see them; only CONTAINERS_STORAGE_CONF and XDG_RUNTIME_DIR are forwarded.

2. An existing /tmp/flakes at 0777 is now a hard error with a message telling the user to chmod 1777 /tmp/flakes. Meta data also moves down one level into /tmp/flakes/<uid>/, so running instances from a pre-upgrade pilot won't be found by the new one.

3. flake-ctl firecracker pull over plain http now fails unless FLAKE_ALLOW_INSECURE_TRANSPORT is set — note the second example in the pull man page uses an https S3 URL, so it still works.

4. The KIS sha256 check fails the pull on a genuine mismatch; a missing/unparsable record or absent sha256sum only warns, so systems without coreutils keep working.