### PR TITLE
Set default log level for firecracker to debug

### DIFF
--- a/firecracker-pilot/src/main.rs
+++ b/firecracker-pilot/src/main.rs
@@ -69,7 +69,7 @@ fn run() -> Result<(), FlakeError> {
 
 fn setup_logger() {
     let env = Env::default()
-        .filter_or("FLAKE_LOG_LEVEL", "trace")
+        .filter_or("FLAKE_LOG_LEVEL", "debug")
         .write_style_or("FLAKE_LOG_STYLE", "always");
 
     env_logger::init_from_env(env);


### PR DESCRIPTION
Instead of trace set debug as default log level