### PR TITLE
Drop user name from cid file

### DIFF
--- a/firecracker-pilot/Cargo.toml
+++ b/firecracker-pilot/Cargo.toml
@@ -19,3 +19,4 @@ serde_yaml = { version = "0.9" }
 strum = { version = "0.25", features = ["derive"] }
 flakes = { version = "3.1.37 ", path = "../common", features = ["json"] }
 libc = { version = "0.2" }
+glob = { version = "0.3" }

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -43,7 +43,7 @@ pub const FIRECRACKER_TEMPLATE:&str =
 pub const FIRECRACKER_VSOCK_PREFIX: &str =
     "sci_cmd_";
 pub const FIRECRACKER_VSOCK_PORT_START: u32 = 49200;
-pub const GC_THRESHOLD: usize = 20;
+pub const GC_THRESHOLD: usize = 1;
 pub const TERM_NAME_MAX_LEN: usize = 32;
 pub const VM_CID: u32 = 3;
 pub const VM_PORT: u32 =

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -24,6 +24,7 @@
 //
 use std::ffi::OsStr;
 use std::{thread, time};
+use glob::glob;
 use flakes::io::IO;
 use std::process::Command;
 use flakes::command::{CommandError, handle_output, CommandExtTrait};
@@ -965,6 +966,25 @@ pub fn gc_meta_files(
                     }
                     delete_file(&vsock_uds_path);
                 }
+                let vsock_uds_path_call_sockets = vsock_uds_path + "_*";
+                for call_socket in glob(&vsock_uds_path_call_sockets).expect(
+                    "Failed to read call socket glob pattern"
+                ) {
+                    match call_socket {
+                        Ok(path) => {
+                            if Lookup::is_debug() {
+                                debug!("Deleting {path:?}");
+                            }
+                            delete_file(&path.display().to_string());
+                        },
+                        Err(ref error) => {
+                            error!(
+                                "Failed to remove {call_socket:?}: {error:?}"
+                            );
+                        }
+                    }
+                }
+
                 let vm_overlay_file = format!(
                     "{}/{}",
                     get_overlay_dir()?,

--- a/podman-pilot/src/defaults.rs
+++ b/podman-pilot/src/defaults.rs
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
-pub const GC_THRESHOLD: i32 = 20;
+pub const GC_THRESHOLD: i32 = 1;
 pub const VAR_EXPANSION_LIMIT: i32 = 10;
 pub const HOST_DEPENDENCIES: &str = "removed";
 pub const SYSTEM_HOST_DEPENDENCIES: &str = "systemfiles";

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -200,9 +200,7 @@ pub fn create(
     let container_ids_dir = init_cid_dir(user)?;
 
     let container_cid_file = format!(
-        "{}/{}{}_{}.cid",
-        container_ids_dir, program_name, suffix,
-        calling_user_name.to_str().unwrap()
+        "{}/{}{}.cid", container_ids_dir, program_name, suffix
     );
     IO::no_symlink(&container_cid_file)?;
 

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -962,8 +962,12 @@ pub fn gc_cid_file(container_cid_file: &String) -> Result<bool, FlakeError> {
     Check if container exists according to the specified
     container_cid_file. Garbage cleanup the container_cid_file
     if no longer present. Return a true value if the container
-    exists, in any other case return false.
+    exists or the given file is not a CID file(ignored),
+    in any other case return false.
     !*/
+    if ! container_cid_file.ends_with(".cid") {
+        return Ok(true);
+    }
     IO::no_symlink(container_cid_file)?;
     let cid = fs::read_to_string(container_cid_file)?;
 


### PR DESCRIPTION
This change is many fold

**Drop user name from cid file**
    
The cid files are organized in /tmp/flakes/UID/flakename.cid The additional user name in the .cid file, as it was before, is now superfluous information and can be dropped.

**Change garbage collector threshold**
    
Set the threshold for all pilots to 1. This will run  the cleanup with every invocation

**Fixed firecracker garbage collector**
    
Make sure to cleanup the sock_NR call ID sockets as well

**Fixed podman pilot garbage collector**
    
Only remove podman pilot related metadata files ending with .cid