### PR TITLE
Add user mode support for firecracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,10 +190,10 @@ runtime = "krun"
 ### Register a shell as a firecracker VM app named: fireshell <a name="four"/>
 
 ```bash
-sudo flake-ctl firecracker pull --name leap \
+flake-ctl firecracker --user pull --name leap \
     --kis-image https://github.com/OSInside/flake-pilot/raw/refs/heads/main/appstore/firecracker/leap.x86_64-1.15.6-0.tar.xz
 
-flake-ctl firecracker register --vm leap \
+flake-ctl firecracker --user register --vm leap \
     --app $HOME/bin/fireshell --target /bin/bash --overlay-size 20GiB
 
 fireshell
@@ -212,10 +212,10 @@ option ```--force-vsock``` when registering the application.
 ### Register claude AI as firecracker VM app named: claude <a name="five"/>
 
 ```bash
-sudo flake-ctl firecracker pull --name claude \
+flake-ctl firecracker --user pull --name claude \
     --kis-image https://github.com/OSInside/flake-pilot/raw/refs/heads/main/appstore/firecracker/claude.x86_64-1.15.6-0.tar.xz
 
-flake-ctl firecracker register --vm claude \
+flake-ctl firecracker --user register --vm claude \
     --app $HOME/bin/claude --target /bin/bash \
     --overlay-size 20GiB --force-vsock --resume
 

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -29,7 +29,8 @@ use std::process::exit;
 
 use lazy_static::lazy_static;
 
-use uzers::{get_current_username};
+use uzers::{get_current_username, get_user_by_name};
+use uzers::os::unix::UserExt;
 
 use ini::Ini;
 
@@ -46,18 +47,26 @@ lazy_static! {
 }
 
 pub fn get_flakes_dir(user: bool) -> String {
+    /*!
+    Provide the directory the flake registrations are stored in
+
+    If the directory is not configured the system wide default
+    location is used. In user mode the registrations belong to
+    the calling user and are stored in its home directory
+    !*/
     let GenericData { flakes_dir, .. } = &flakes_config(user).generic;
-    if flakes_dir.is_none() {
-        if ! user {
-            defaults::FLAKES_DIR.to_string()
-        } else {
-            error!("No flakes_dir configured");
-            error!("Please check {}", get_user_flakes_config());
-            error!("More details on rootless mode in 'man flake-pilot'");
-            exit(1);
+    match flakes_dir {
+        Some(flakes_dir) => flakes_dir.clone(),
+        None => {
+            if ! user {
+                defaults::FLAKES_DIR.to_string()
+            } else {
+                error!("No flakes_dir configured");
+                error!("Please check {}", get_user_flakes_config());
+                error!("More details on rootless mode in 'man flake-pilot'");
+                exit(1);
+            }
         }
-    } else {
-        flakes_dir.clone().unwrap()
     }
 }
 
@@ -114,12 +123,19 @@ fn flakes_config(user: bool) -> &'static FlakesConfig {
     }
 }
 
-fn get_user_flakes_config() -> String {
+fn get_user_home() -> String {
+    /*!
+    Home directory of the user calling the program
+    !*/
     let current_user = get_current_username().unwrap();
-    let flake_config_path = format!(
-        "/home/{}/.config/flakes.yml", current_user.to_str().unwrap()
-    );
-    flake_config_path
+    match get_user_by_name(&current_user) {
+        Some(user) => user.home_dir().to_string_lossy().to_string(),
+        None => format!("/home/{}", current_user.to_string_lossy())
+    }
+}
+
+fn get_user_flakes_config() -> String {
+    format!("{}/{}", get_user_home(), defaults::FLAKES_CONFIG_USER)
 }
 
 fn read_flakes_config_user() -> FlakesConfig {

--- a/common/src/defaults.rs
+++ b/common/src/defaults.rs
@@ -23,6 +23,10 @@
 //
 pub const FLAKES_CONFIG: &str = "/etc/flakes.yml";
 pub const FLAKES_DIR: &str = "/usr/share/flakes";
+// User specific locations, relative to the home directory
+// of the user calling the program
+pub const FLAKES_CONFIG_USER: &str = ".config/flakes.yml";
+pub const FLAKES_DIR_USER: &str = ".config/flakes";
 pub const PODMAN_IDS_DIR: &str = "/tmp/flakes";
 pub const FIRECRACKER_IDS_DIR: &str = "/tmp/flakes";
 pub const FLAKES_REGISTRY: &str = "/usr/share/flakes/storage";

--- a/completion/flake-ctl
+++ b/completion/flake-ctl
@@ -133,7 +133,7 @@ __flake_ctl_main() {
                 ;;
             firecracker_*)
                 command="firecracker" && __comp_reply "
-                    help pull register remove
+                    help pull register remove --user
                 " && return 0
                 ;;
             podman_*)

--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -28,7 +28,10 @@ registration. If the registered application is requested as
 Consequently calling **myapp** will effectively call **firecracker-pilot**.
 firecracker-pilot now reads the calling program basename, which is **myapp**
 and looks up all the registration metadata stored in
-`/usr/share/flakes`
+`/usr/share/flakes`. If there is no system wide registration
+for the given application name, the registration directory of
+the calling user, `~/.config/flakes`, is used as created by
+**flake-ctl firecracker --user register**
 
 Below `/usr/share/flakes` each application is registered
 with the following layout:
@@ -169,6 +172,9 @@ FILES
 * /var/lib/firecracker/images
 * /var/lib/firecracker/storage
 * /etc/flakes
+* ~/.config/flakes
+* ~/.config/flakes/firecracker/images
+* ~/.config/flakes/firecracker/storage
 
 AUTHOR
 ------

--- a/doc/flake-ctl-firecracker-pull.rst
+++ b/doc/flake-ctl-firecracker-pull.rst
@@ -12,7 +12,7 @@ SYNOPSIS
 .. code:: bash
 
     USAGE:
-        flake-ctl firecracker pull [OPTIONS] --name <NAME> <--kis-image <KIS_IMAGE>|--rootfs <ROOTFS>|--kernel <KERNEL>>
+        flake-ctl firecracker [--user] pull [OPTIONS] --name <NAME> <--kis-image <KIS_IMAGE>|--rootfs <ROOTFS>|--kernel <KERNEL>>
 
     OPTIONS:
         --force
@@ -21,12 +21,15 @@ SYNOPSIS
         --kis-image <KIS_IMAGE>
         --name <NAME>
         --rootfs <ROOTFS>
+        --user
 
 DESCRIPTION
 -----------
 
 Pull the components of a firecracker image from the given location
-into `/var/lib/firecracker/images/NAME` on the local machine.
+into `/var/lib/firecracker/images/NAME` on the local machine. In
+user mode the image is stored in the registry of the calling user
+below `~/.config/flakes/firecracker/images/NAME`.
 After completion the available firecracker images can be listed via:
 
 .. code:: bash
@@ -73,6 +76,12 @@ OPTIONS
 --rootfs <ROOTFS>
 
   Single rootfs image to pull into local image store
+
+--user
+
+  Pull into the user specific registry, rootless mode. The image
+  is stored below `~/.config/flakes/firecracker/images`.
+  Requesting user mode as the root user has no effect
 
 ENVIRONMENT
 -----------

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -12,7 +12,7 @@ SYNOPSIS
 .. code:: bash
 
    USAGE:
-       flake-ctl firecracker register [OPTIONS] --vm <VM> --app <APP>
+       flake-ctl firecracker [--user] register [OPTIONS] --vm <VM> --app <APP>
 
 
    OPTIONS:
@@ -26,6 +26,7 @@ SYNOPSIS
        --overlay-size <OVERLAY_SIZE>
        --run-as <RUN_AS>
        --target <TARGET>
+       --user
        --vm <VM>
 
 DESCRIPTION
@@ -36,6 +37,8 @@ virtual machine. The registration process is two fold:
 
 1. Create the application symlink pointing to `/usr/bin/firecracker-pilot`
 2. Create the application default configuration below `/usr/share/flakes`.
+   In user mode the configuration is created below `~/.config/flakes`
+   and refers to a VM of the registry of the calling user.
    Each application registered is called a **flake**
 
 On successful completion the registered *--app* name can be called
@@ -101,6 +104,13 @@ OPTIONS
   An absolute path to the application in the VM. Use this option if the application path
   on the host should be different to the application path inside of the VM
 
+--user
+
+  Register in the user specific registry, rootless mode. The flake
+  configuration is created below `~/.config/flakes` and the VM is
+  looked up in `~/.config/flakes/firecracker/images`. Requesting
+  user mode as the root user has no effect
+
 --vm <VM>
 
   A virtual machine name. The name must match with a name in the local firecracker
@@ -111,6 +121,7 @@ FILES
 -----
 
 * /usr/share/flakes
+* ~/.config/flakes
 * /etc/flakes.yml
 
 EXAMPLE

--- a/doc/flake-ctl-firecracker-remove.rst
+++ b/doc/flake-ctl-firecracker-remove.rst
@@ -12,10 +12,11 @@ SYNOPSIS
 .. code:: bash
 
    USAGE:
-       flake-ctl firecracker remove <--vm <VM>|--app <APP>>
+       flake-ctl firecracker [--user] remove <--vm <VM>|--app <APP>>
 
    OPTIONS:
        --app <APP>
+       --user
        --vm <VM>
 
 DESCRIPTION
@@ -28,6 +29,7 @@ Remove registration(s). The command operates in two modes:
    In this mode the command deletes the specified application if it
    is a link pointing to `/usr/bin/firecracker-pilot`. It then also
    deletes the application configuration from `/usr/share/flakes`
+   respectively from `~/.config/flakes` in user mode
 
 2. Remove a VM including all its registered applications via **--vm**
 
@@ -42,15 +44,24 @@ OPTIONS
 
   Application absolute path to be removed from host
 
+--user
+
+  Remove from the user specific registry, rootless mode.
+  Requesting user mode as the root user has no effect
+
 --vm <VM>
 
   VM basename as provided via **ls -1 /var/lib/firecracker/images**
+  respectively **ls -1 ~/.config/flakes/firecracker/images**
+  in user mode
 
 FILES
 -----
 
 * /usr/share/flakes
 * /var/lib/firecracker/images
+* ~/.config/flakes
+* ~/.config/flakes/firecracker/images
 
 EXAMPLE
 -------

--- a/firecracker-pilot/src/app_path.rs
+++ b/firecracker-pilot/src/app_path.rs
@@ -55,12 +55,30 @@ pub fn basename(program_path: &String) -> String {
     program_name
 }
 
+fn program_flakes_dir(program_basename: &String) -> String {
+    /*!
+    Provide the flakes directory containing the registration
+    of the given program_basename
+
+    A system wide registration is preferred. If it does not exist
+    the registration directory of the calling user is used
+    !*/
+    let config_file = format!(
+        "{}/{}.yaml", get_flakes_dir(false), program_basename
+    );
+    if Path::new(&config_file).exists() {
+        get_flakes_dir(false)
+    } else {
+        get_flakes_dir(true)
+    }
+}
+
 pub fn program_config_file(program_basename: &String) -> String {
     /*!
     Provide expected config file path for the given program_basename
     !*/
     let config_file = &format!(
-        "{}/{}.yaml", get_flakes_dir(false), program_basename
+        "{}/{}.yaml", program_flakes_dir(program_basename), program_basename
     );
     config_file.to_string()
 }
@@ -70,7 +88,7 @@ pub fn program_config_dir(program_basename: &String) -> String {
     Provide expected config directory for the given program_basename
     !*/
     let config_dir = &format!(
-        "{}/{}.d", get_flakes_dir(false), program_basename
+        "{}/{}.d", program_flakes_dir(program_basename), program_basename
     );
     config_dir.to_string()
 }

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -24,7 +24,7 @@
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use strum::Display;
-use std::{env, fs, path::PathBuf};
+use std::{env, fs, path::Path, path::PathBuf};
 use flakes::config::get_flakes_dir;
 
 lazy_static! {
@@ -55,11 +55,28 @@ fn load_config() -> Config<'static> {
     and attached to the master program_name.yaml file. The result
     is send to the Yaml parser
     !*/
+    // first try to find system wide config
+    let mut usermode = false;
+
     let base_path = get_base_path();
     let base_path = base_path.file_name().unwrap().to_str().unwrap();
-    let base_yaml = fs::read_to_string(config_file(base_path));
+    let mut base_file = config_file(base_path, usermode);
 
-    let mut extra_yamls: Vec<_> = fs::read_dir(config_dir(base_path))
+    if ! Path::new(&base_file).exists() {
+        // no system wide config found, try user specific
+        usermode = true;
+        base_file = config_file(base_path, usermode);
+        if ! Path::new(&base_file).exists() {
+            panic!(
+                "No user/system wide flake registration found for: {}",
+                base_path
+            )
+        }
+    }
+
+    let base_yaml = fs::read_to_string(&base_file);
+
+    let mut extra_yamls: Vec<_> = fs::read_dir(config_dir(base_path, usermode))
         .into_iter()
         .flatten()
         .flatten()
@@ -91,12 +108,12 @@ pub fn config_from_str(input: &str) -> Config<'static> {
     serde_yaml::from_str(content).unwrap()
 }
 
-pub fn config_file(program: &str) -> String {
-    format!("{}/{}.yaml", get_flakes_dir(false), program)
+pub fn config_file(program: &str, usermode: bool) -> String {
+    format!("{}/{}.yaml", get_flakes_dir(usermode), program)
 }
 
-fn config_dir(program: &str) -> String {
-    format!("{}/{}.d", get_flakes_dir(false), program)
+fn config_dir(program: &str, usermode: bool) -> String {
+    format!("{}/{}.d", get_flakes_dir(usermode), program)
 }
 
 #[derive(Deserialize)]

--- a/firecracker-pilot/src/tests.rs
+++ b/firecracker-pilot/src/tests.rs
@@ -56,6 +56,6 @@ vm:
 
 #[test]
 fn test_program_config_file() {
-    let config_file = config_file("app");
+    let config_file = config_file("app", false);
     assert_eq!("/usr/share/flakes/app.yaml", config_file);
 }

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -176,6 +176,7 @@ pub fn create_vm_config(
     force_vsock: bool,
     includes_tar: Option<Vec<String>>,
     includes_path: Option<Vec<String>>,
+    usermode: bool,
 ) -> bool {
     /*!
     Create app configuration for the firecracker engine.
@@ -192,7 +193,7 @@ pub fn create_vm_config(
         .to_str()
         .unwrap();
     let app_config_file = format!(
-        "{}/{}.yaml", get_flakes_dir(false), app_basename
+        "{}/{}.yaml", get_flakes_dir(usermode), app_basename
     );
     match app_config::AppConfig::save_vm(
         Path::new(&app_config_file),
@@ -206,6 +207,7 @@ pub fn create_vm_config(
         force_vsock,
         includes_tar,
         includes_path,
+        usermode,
     ) {
         Ok(_) => true,
         Err(error) => {
@@ -574,7 +576,7 @@ pub fn purge(app: &str, engine: &str, usermode: bool) {
         podman::purge_container(app, usermode)
     }
     if engine == defaults::FIRECRACKER_PILOT {
-        firecracker::purge_vm(app)
+        firecracker::purge_vm(app, usermode)
     }
 }
 

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -27,6 +27,7 @@ use std::path::Path;
 use serde::{Serialize, Deserialize};
 use serde_yaml::{self};
 use crate::defaults;
+use crate::firecracker;
 
 type GenericError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -183,11 +184,12 @@ impl AppConfig {
         force_vsock: bool,
         includes_tar: Option<Vec<String>>,
         includes_path: Option<Vec<String>>,
+        usermode: bool,
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
         !*/
-        let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, vm);
+        let image_dir = firecracker::get_image_dir(vm, usermode);
         let template = std::fs::File::open(defaults::FLAKE_TEMPLATE_FIRECRACKER)
             .unwrap_or_else(|_| panic!(
                 "Failed to open {}", defaults::FLAKE_TEMPLATE_FIRECRACKER)

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -47,6 +47,10 @@ pub enum Commands {
     },
     /// Load and register FireCracker VM applications
     Firecracker {
+        /// Use user specific registry, rootless mode
+        #[clap(long)]
+        user: bool,
+
         #[clap(subcommand)]
         command: Firecracker,
     },

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -34,8 +34,14 @@ pub const FLAKE_TEMPLATE_FIRECRACKER:&str =
     "/etc/flakes/firecracker-flake.yaml";
 pub const FIRECRACKER_REGISTRY_DIR:&str =
     "/var/lib/firecracker";
-pub const FIRECRACKER_IMAGES_DIR:&str =
-    "/var/lib/firecracker/images";
+// Name of the firecracker registry inside of the flakes
+// directory of the calling user. Used in user mode only
+pub const FIRECRACKER_REGISTRY_NAME:&str =
+    "firecracker";
+pub const FIRECRACKER_IMAGES_NAME:&str =
+    "images";
+pub const FIRECRACKER_STORAGE_NAME:&str =
+    "storage";
 pub const FIRECRACKER_INITRD_NAME:&str =
     "initrd";
 pub const FIRECRACKER_KERNEL_NAME:&str =

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -38,6 +38,51 @@ use crate::{app, app_config};
 
 use crate::fetch::{fetch_file, send_request};
 
+pub fn get_registry_dir(usermode: bool) -> String {
+    /*!
+    Provide the toplevel firecracker registry directory
+
+    In user mode the registry is a private directory of the
+    calling user below its flakes directory. In all other
+    cases the system wide registry is used
+    !*/
+    if usermode {
+        format!(
+            "{}/{}", get_flakes_dir(true), defaults::FIRECRACKER_REGISTRY_NAME
+        )
+    } else {
+        defaults::FIRECRACKER_REGISTRY_DIR.to_string()
+    }
+}
+
+pub fn get_images_dir(usermode: bool) -> String {
+    /*!
+    Provide the directory the firecracker images are stored in
+    !*/
+    format!(
+        "{}/{}", get_registry_dir(usermode), defaults::FIRECRACKER_IMAGES_NAME
+    )
+}
+
+pub fn get_image_dir(name: &str, usermode: bool) -> String {
+    /*!
+    Provide the directory of the image registered as name
+    !*/
+    format!("{}/{}", get_images_dir(usermode), name)
+}
+
+pub fn registry_user(usermode: bool) -> &'static str {
+    /*!
+    Provide the user owning the firecracker registry
+
+    The system wide registry belongs to root whereas the user
+    registry belongs to the calling user itself. The latter is
+    expressed as an empty user which means no privilege change
+    is needed to operate on the registry
+    !*/
+    if usermode { "" } else { "root" }
+}
+
 pub fn init_toplevel_image_dir(registry_dir: &str) -> bool {
     /*!
     Create firecracker registry directory layout
@@ -55,8 +100,12 @@ pub fn init_toplevel_image_dir(registry_dir: &str) -> bool {
         }
     }
     let mut subdirs: Vec<String> = Vec::new();
-    subdirs.push(format!("{real_registry_dir}/images"));
-    subdirs.push(format!("{real_registry_dir}/storage"));
+    subdirs.push(format!(
+        "{}/{}", real_registry_dir, defaults::FIRECRACKER_IMAGES_NAME
+    ));
+    subdirs.push(format!(
+        "{}/{}", real_registry_dir, defaults::FIRECRACKER_STORAGE_NAME
+    ));
     for subdir in subdirs {
         if Path::new(&subdir).exists() {
             continue
@@ -115,21 +164,21 @@ fn tempdir() -> io::Result<TempDir> {
 }
 
 pub async fn pull_component_image(
-    name: &String, rootfs_uri: Option<&String>, kernel_uri: Option<&String>,
-    initrd_uri: Option<&String>, force: bool
+    name: &str, rootfs_uri: Option<&String>, kernel_uri: Option<&String>,
+    initrd_uri: Option<&String>, force: bool, usermode: bool
 ) -> i32 {
     /*!
     Fetch components image consisting out of rootfs, kernel and
     optional initrd.
     !*/
     let mut result = 255;
-    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    let image_dir = get_image_dir(name, usermode);
     struct Component<'a> {
         uri: String,
         file: Cow<'a, str>
     }
     info!("Fetching Component image...");
-    if ! pull_new(name, force) {
+    if ! pull_new(name, force, usermode) {
         return result
     }
     match tempdir() {
@@ -253,7 +302,7 @@ pub async fn pull_component_image(
             }
 
             // Move to final firecracker image store
-            if ! mv(&tmp_dir_path, &image_dir, "root") {
+            if ! mv(&tmp_dir_path, &image_dir, registry_user(usermode)) {
                 return result
             }
         },
@@ -268,7 +317,7 @@ pub async fn pull_component_image(
 }
 
 pub async fn pull_kis_image(
-    name: &String, uri: Option<&String>, force: bool
+    name: &str, uri: Option<&String>, force: bool, usermode: bool
 ) -> i32 {
     /*!
     Fetch the data provided in uri and treat it as a KIWI
@@ -277,11 +326,11 @@ pub async fn pull_kis_image(
     components; rootfs-image, kernel and optional initrd
     !*/
     let mut result = 255;
-    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    let image_dir = get_image_dir(name, usermode);
 
     info!("Fetching KIS image...");
 
-    if ! pull_new(name, force) {
+    if ! pull_new(name, force, usermode) {
         return result
     }
 
@@ -386,7 +435,7 @@ pub async fn pull_kis_image(
             }
 
             // Move to final firecracker image store
-            if ! mv(&work_dir, &image_dir, "root") {
+            if ! mv(&work_dir, &image_dir, registry_user(usermode)) {
                 return result
             }
         },
@@ -504,15 +553,28 @@ fn checksum(image: &str, size: Option<u64>) -> Option<String> {
     }
 }
 
+fn run_as(program: &str, user: &str) -> Command {
+    /*!
+    Create a call of the given program
+
+    An empty user indicates that the program is called with the
+    privileges of the caller. In all other cases the call is
+    passed to sudo to run it as the specified user
+    !*/
+    if user.is_empty() {
+        return Command::new(program)
+    }
+    let mut call = Command::new("sudo");
+    call.arg("--user").arg(user).arg(program);
+    call
+}
+
 pub fn mkdir(dirname: &String, user: &str) -> bool {
     /*!
-    Make directory via sudo
+    Make directory
     !*/
-    let mut call = Command::new("sudo");
-    if ! user.is_empty() {
-        call.arg("--user").arg(user);
-    }
-    call.arg("mkdir").arg("-p").arg(dirname);
+    let mut call = run_as("mkdir", user);
+    call.arg("-p").arg(dirname);
     match call.status() {
         Ok(_) => { },
         Err(error) => {
@@ -525,13 +587,10 @@ pub fn mkdir(dirname: &String, user: &str) -> bool {
 
 pub fn mv(source: &str, target: &String, user: &str) -> bool {
     /*!
-    Move file via sudo
+    Move file
     !*/
-    let mut call = Command::new("sudo");
-    if ! user.is_empty() {
-        call.arg("--user").arg(user);
-    }
-    call.arg("mv").arg(source).arg(target);
+    let mut call = run_as("mv", user);
+    call.arg(source).arg(target);
     match call.status() {
         Ok(_) => { },
         Err(error) => {
@@ -544,13 +603,10 @@ pub fn mv(source: &str, target: &String, user: &str) -> bool {
 
 pub fn copy(source: &str, target: &String, user: &str) -> bool {
     /*!
-    Copy file via sudo
+    Copy file
     !*/
-    let mut call = Command::new("sudo");
-    if ! user.is_empty() {
-        call.arg("--user").arg(user);
-    }
-    call.arg("cp").arg(source).arg(target);
+    let mut call = run_as("cp", user);
+    call.arg(source).arg(target);
     match call.status() {
         Ok(_) => { },
         Err(error) => {
@@ -567,11 +623,8 @@ pub fn mount_fs_image(
     /*!
     Mount filesystem image
     !*/
-    let mut call = Command::new("sudo");
-    if ! user.is_empty() {
-        call.arg("--user").arg(user);
-    }
-    call.arg("mount").arg(fs_name).arg(mount_point);
+    let mut call = run_as("mount", user);
+    call.arg(fs_name).arg(mount_point);
     match call.status() {
         Ok(_) => { },
         Err(error) => {
@@ -586,11 +639,8 @@ pub fn umount(mount_point: &str, user: &str) -> bool {
     /*!
     Umount given mount_point
     !*/
-    let mut call = Command::new("sudo");
-    if ! user.is_empty() {
-        call.arg("--user").arg(user);
-    }
-    call.arg("umount").arg(mount_point);
+    let mut call = run_as("umount", user);
+    call.arg(mount_point);
     match call.status() {
         Ok(_) => { },
         Err(error) => {
@@ -602,14 +652,14 @@ pub fn umount(mount_point: &str, user: &str) -> bool {
 }
 
 
-pub fn pull_new(name: &String, force: bool) -> bool {
+pub fn pull_new(name: &str, force: bool, usermode: bool) -> bool {
     /*!
     Initialize new pull
     !*/
-    if ! init_toplevel_image_dir(defaults::FIRECRACKER_REGISTRY_DIR) {
+    if ! init_toplevel_image_dir(&get_registry_dir(usermode)) {
         return false
     }
-    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, name);
+    let image_dir = get_image_dir(name, usermode);
     if force && Path::new(&image_dir).exists() {
         match fs::remove_dir_all(&image_dir) {
             Ok(_) => { },
@@ -626,15 +676,15 @@ pub fn pull_new(name: &String, force: bool) -> bool {
     true
 }
 
-pub fn purge_vm(vm: &str) {
+pub fn purge_vm(vm: &str, usermode: bool) {
     /*!
     Iterate over all yaml config files and find those connected
     to the VM. Delete all app registrations for this
     VM and also delete the VM from the local registry
     !*/
-    for app_name in app::app_names(false) {
+    for app_name in app::app_names(usermode) {
         let config_file = format!(
-            "{}/{}.yaml", get_flakes_dir(false), app_name
+            "{}/{}.yaml", get_flakes_dir(usermode), app_name
         );
         match app_config::AppConfig::init_from_file(Path::new(&config_file)) {
             Ok(app_conf) => {
@@ -642,7 +692,7 @@ pub fn purge_vm(vm: &str) {
                     if vm == vm_conf.name {
                         app::remove(
                             &vm_conf.host_app_path,
-                            defaults::FIRECRACKER_PILOT, false, false, false
+                            defaults::FIRECRACKER_PILOT, usermode, false, false
                         );
                     }
                 }
@@ -654,7 +704,7 @@ pub fn purge_vm(vm: &str) {
             }
         };
     }
-    let image_dir = format!("{}/{}", defaults::FIRECRACKER_IMAGES_DIR, vm);
+    let image_dir = get_image_dir(vm, usermode);
     match fs::remove_dir_all(&image_dir) {
         Ok(_) => { },
         Err(error) => {

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -39,6 +39,7 @@ pub mod fetch;
 use flakes::config::get_flakes_dir;
 use flakes::user::{User, mkdir};
 use uzers::get_current_username;
+use std::fs;
 
 #[tokio::main]
 async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
@@ -46,22 +47,18 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
 
     let args = cli::parse_args();
 
-    // The flake registry is read by the pilots to learn how to run
-    // an application. It is therefore only writable by root
-    mkdir(&get_flakes_dir(false), "755", User::ROOT)?;
+    // In user mode only resources of the calling user are touched
+    let user = usermode(&args);
+
+    init_flakes_dir(user)?;
 
     match &args.command {
         // list
-        cli::Commands::List { mut user, format } => {
-            let calling_user_name = get_current_username().unwrap();
-            if calling_user_name == "root" {
-                // if --user is used for the root user, we ignore it
-                user = false
-            }
+        cli::Commands::List { format, .. } => {
             app::list(user, *format);
         },
         // firecracker engine
-        cli::Commands::Firecracker { command } => {
+        cli::Commands::Firecracker { command, .. } => {
             match &command {
                 // pull
                 cli::Firecracker::Pull {
@@ -70,14 +67,14 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                     if ! kis_image.is_none() {
                         exit(
                             firecracker::pull_kis_image(
-                                name, kis_image.as_ref(), *force
+                                name, kis_image.as_ref(), *force, user
                             ).await
                         );
                     } else {
                         exit(
                             firecracker::pull_component_image(
                                 name, rootfs.as_ref(), kernel.as_ref(),
-                                initrd.as_ref(), *force
+                                initrd.as_ref(), *force, user
                             ).await
                         );
                     }
@@ -91,16 +88,16 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                         app::remove(
                             app,
                             defaults::FIRECRACKER_PILOT,
-                            false,
+                            user,
                             true,
                             *force
                         );
                     }
-                    if app::init(Some(app), false) {
+                    if app::init(Some(app), user) {
                         let mut ok = app::register(
                             Some(app), target.as_ref(),
                             defaults::FIRECRACKER_PILOT,
-                            false
+                            user
                         );
                         if ok {
                             ok = app::create_vm_config(
@@ -114,12 +111,13 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                                 *force_vsock,
                                 include_tar.as_ref().cloned(),
                                 include_path.as_ref().cloned(),
+                                user,
                             );
                         }
                         if ! ok {
                             app::remove(
                                 app, defaults::FIRECRACKER_PILOT,
-                                false,
+                                user,
                                 true,
                                 *force
                             );
@@ -134,7 +132,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                     if ! app.is_none() && ! app::remove(
                         app.as_ref().map(String::as_str).unwrap(),
                         defaults::FIRECRACKER_PILOT,
-                        false,
+                        user,
                         false,
                         false
                     ) {
@@ -144,19 +142,14 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                         app::purge(
                             vm.as_ref().map(String::as_str).unwrap(),
                             defaults::FIRECRACKER_PILOT,
-                            false
+                            user
                         );
                     }
                 }
             }
         },
         // podman engine
-        cli::Commands::Podman { command, mut user } => {
-            let calling_user_name = get_current_username().unwrap();
-            if calling_user_name == "root" {
-                // if --user is used for the root user, we ignore it
-                user = false
-            }
+        cli::Commands::Podman { command, .. } => {
             match &command {
                 // pull
                 cli::Podman::Pull { uri } => {
@@ -244,6 +237,36 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
         },
     }
     Ok(ExitCode::SUCCESS)
+}
+
+fn usermode(args: &cli::Cli) -> bool {
+    /*!
+    Check if the command should operate on the resources of the
+    calling user only. For the root user there is no user mode,
+    a --user request from root is ignored
+    !*/
+    let usermode = match &args.command {
+        cli::Commands::List { user, .. } => *user,
+        cli::Commands::Firecracker { user, .. } => *user,
+        cli::Commands::Podman { user, .. } => *user
+    };
+    usermode && get_current_username().unwrap() != "root"
+}
+
+fn init_flakes_dir(usermode: bool) -> Result<(), Box<dyn std::error::Error>> {
+    /*!
+    Create the directory the flake registrations are stored in
+    !*/
+    if usermode {
+        // The user flake registry belongs to the calling user and
+        // is therefore created with the privileges of that user
+        fs::create_dir_all(get_flakes_dir(true))?;
+    } else {
+        // The flake registry is read by the pilots to learn how to
+        // run an application. It is therefore only writable by root
+        mkdir(&get_flakes_dir(false), "755", User::ROOT)?;
+    }
+    Ok(())
 }
 
 fn setup_logger() {


### PR DESCRIPTION
Similar to the podman-pilot now also the firecracker-pilot now supports a user mode. In this mode images gets downloaded into the calling user's home directory and flake registrations are stored there too.