### PR TITLE
Add support for init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ mkdir -p ~/bin
 export PATH=$PATH:$HOME/bin
 ```
 
+The examples register the apps for the calling user. The setup
+for this rootless mode is created once via:
+
+```bash
+flake-ctl init --user
+```
+
 ### Register Amazon's SDK utility as a container app named: aws <a name="one"/>
 
 ```bash

--- a/common/src/config.rs
+++ b/common/src/config.rs
@@ -63,6 +63,7 @@ pub fn get_flakes_dir(user: bool) -> String {
             } else {
                 error!("No flakes_dir configured");
                 error!("Please check {}", get_user_flakes_config());
+                error!("Run 'flake-ctl init --user' to create the setup");
                 error!("More details on rootless mode in 'man flake-pilot'");
                 exit(1);
             }
@@ -78,6 +79,7 @@ pub fn get_podman_storage_conf(user: bool) -> String {
         } else {
             error!("No podman_storage_conf configured");
             error!("Please check {}", get_user_flakes_config());
+            error!("Run 'flake-ctl init --user' to create the setup");
             exit(1);
         }
     } else {
@@ -93,6 +95,7 @@ pub fn get_podman_ids_dir(user: bool) -> String {
         } else {
             error!("No podman_ids_dir configured");
             error!("Please check {}", get_user_flakes_config());
+            error!("Run 'flake-ctl init --user' to create the setup");
             exit(1);
         }
     } else {
@@ -108,6 +111,7 @@ pub fn get_firecracker_ids_dir(user: bool) -> String {
         } else {
             error!("No firecracker_ids_dir configured");
             error!("Please check {}", get_user_flakes_config());
+            error!("Run 'flake-ctl init --user' to create the setup");
             exit(1);
         }
     } else {

--- a/completion/flake-ctl
+++ b/completion/flake-ctl
@@ -53,6 +53,10 @@ __flake_ctl_help() {
     __comp_reply ""
 }
 
+__flake_ctl_init() {
+    __comp_reply_unused "--force --user --help"
+}
+
 __flake_ctl_list() {
     declare prev="${prev}"
     if [ "${prev}" = "--format" ];then
@@ -163,6 +167,10 @@ __flake_ctl_main() {
             help_*)
                 command="help" && __comp_reply "" && return 0
                 ;;
+            init_*)
+                command="init" && __flake_ctl_complete_command "init" \
+                    && return 0
+                ;;
             list_*)
                 command="list" && __flake_ctl_complete_command "list" \
                     && return 0
@@ -177,6 +185,7 @@ __flake_ctl_main() {
             --version
             firecracker
             help
+            init
             list
             podman
         "

--- a/doc/flake-ctl-init.rst
+++ b/doc/flake-ctl-init.rst
@@ -1,0 +1,97 @@
+FLAKE-CTL-INIT(8)
+=================
+
+NAME
+----
+
+**flake-ctl init** - Create the setup to run flake applications
+
+SYNOPSIS
+--------
+
+.. code:: bash
+
+   USAGE:
+       flake-ctl init [OPTIONS]
+
+   OPTIONS:
+       --user
+       --force
+       --help
+
+DESCRIPTION
+-----------
+
+Create the user specific setup to run flake applications.
+
+The system wide setup is provided with the flake-pilot package.
+A user who wants to register and run flake applications without
+root privileges needs its own setup below the home directory.
+The command creates it as follows:
+
+1. The flakes directory of the calling user, $HOME/.config/flakes,
+   with the sub directories `podman` and `firecracker` used by the
+   respective engine
+
+2. The user specific flakes configuration file
+   $HOME/.config/flakes.yml. It points the flake registry and the
+   podman storage of the user to the directories created in the
+   first step. The meta data directories of the pilots are taken
+   from the system wide configuration file /etc/flakes.yml
+
+3. The podman storage configuration file
+   $HOME/.config/flakes/podman/storage.conf. It points podman to
+   a storage location of the calling user
+
+The created files are meant to be adjusted as desired. Therefore
+a file which already exists is kept and only reported unless the
+**--force** option is given.
+
+After the setup was created, flake applications can be registered
+and run with the **--user** option of the respective flake-ctl
+command. To let podman commands operate on the flake storage of
+the user, export the storage configuration as it is shown at the
+end of the setup:
+
+.. code:: bash
+
+   export CONTAINERS_STORAGE_CONF=$HOME/.config/flakes/podman/storage.conf
+
+OPTIONS
+-------
+
+--user
+
+  Create the setup for the calling user. This is the only setup
+  the command can create. Calling it as the root user is an error
+
+--force
+
+  Create the configuration files from scratch, even if they
+  already exist. Existing files are overwritten and adjustments
+  made to them are lost
+
+FILES
+-----
+
+* /etc/flakes.yml
+* $HOME/.config/flakes.yml
+* $HOME/.config/flakes
+* $HOME/.config/flakes/podman/storage.conf
+
+EXAMPLE
+-------
+
+.. code:: bash
+
+   $ flake-ctl init --user
+
+AUTHOR
+------
+
+Marcus Schäfer
+
+COPYRIGHT
+---------
+
+(c) 2026, Marcus Schäfer

--- a/doc/flake-ctl.rst
+++ b/doc/flake-ctl.rst
@@ -20,6 +20,7 @@ SYNOPSIS
 
    SUBCOMMANDS:
        help         Print this message or the help of the given subcommand(s)
+       init         Create the setup to run flake applications
        list         List registered container applications
        podman       Load and register OCI applications
        firecracker  Load and register VM applications
@@ -41,7 +42,7 @@ registration process.
 SEE ALSO
 --------
 
-podman-pilot(8), flake-ctl-list(8), flake-ctl-podman-load(8), flake-ctl-podman-register(8), flake-ctl-podman-remove(8), flake-ctl-podman-show(8), firecracker-pilot(8), flake-ctl-firecracker-load(8), flake-ctl-firecracker-register(8), flake-ctl-firecracker-remove(8), flake-ctl-firecracker-show(8)
+podman-pilot(8), flake-ctl-init(8), flake-ctl-list(8), flake-ctl-podman-load(8), flake-ctl-podman-register(8), flake-ctl-podman-remove(8), flake-ctl-podman-show(8), firecracker-pilot(8), flake-ctl-firecracker-load(8), flake-ctl-firecracker-register(8), flake-ctl-firecracker-remove(8), flake-ctl-firecracker-show(8)
 
 AUTHOR
 ------

--- a/doc/flake-pilot.rst
+++ b/doc/flake-pilot.rst
@@ -53,39 +53,21 @@ FILES
        # flake storage location.
        podman_storage_conf: /etc/flakes/storage.conf
 
-  To setup a user specific configuration for running flake applications
-  perform the following steps:
+  The user specific configuration for running flake applications
+  is created by the following command:
 
-  1. Create a custom directory structure below $HOME/.config/flakes as follows:
+  .. code:: sh
 
-     .. code:: sh
+     flake-ctl init --user
 
-        mkdir -p $HOME/.config/flakes/podman
-        mkdir -p $HOME/.config/flakes/firecracker
+  For details see:
 
-  2. Create a copy of the system wide configuration file /etc/flakes.yml
-     to $HOME/.config/flakes.yml and adjust the configuration as desired.
-     For example:
+  - man flake-ctl-init
 
-      .. code:: yaml
+SEE ALSO
+--------
 
-         generic:
-           flakes_dir: /home/USERNAME/.config/flakes
-           podman_storage_conf: /home/USERNAME/.config/flakes/podman/storage.conf
-           podman_ids_dir: /tmp/flakes
-           firecracker_ids_dir: /tmp/flakes
-
-  3. Create a copy of the system wide flakes podman storage configuration file
-     /etc/flakes/storage.conf to $HOME/.config/flakes/podman/storage.conf
-     and adjust the storage configuration as desired. For example:
-
-      .. code:: ini
-
-         [storage]
-         driver = "overlay"
-         graphroot = "/home/USERNAME/.config/flakes/podman/storage"
-         rootless_storage_path = "/home/USERNAME/.config/flakes/podman/storage"
-         runroot= "/home/USERNAME/.config/flakes/podman/storage/runroot"
+flake-ctl(8), flake-ctl-init(8), podman-pilot(8), firecracker-pilot(8)
 
 AUTHOR
 ------

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -54,6 +54,17 @@ pub enum Commands {
         #[clap(subcommand)]
         command: Firecracker,
     },
+    /// Create the setup to run flake applications
+    Init {
+        /// Create the setup for the calling user, rootless mode
+        #[clap(long)]
+        user: bool,
+
+        /// Create the configuration files from scratch, even if
+        /// they already exist. Existing files are overwritten
+        #[clap(long)]
+        force: bool,
+    },
     /// List registered flake applications
     List {
         /// Pull into user specific podman registry

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -52,6 +52,18 @@ pub const FIRECRACKER_CHECKSUM_NAME:&str =
     "checksum";
 pub const FIRECRACKER_SCI:&str =
     "/usr/lib/flake-pilot/sci";
+// Name of the podman setup directory inside of the flakes
+// directory of the calling user. Used in user mode only
+pub const PODMAN_REGISTRY_NAME:&str =
+    "podman";
+pub const PODMAN_STORAGE_CONF_NAME:&str =
+    "storage.conf";
+pub const PODMAN_STORAGE_NAME:&str =
+    "storage";
+pub const PODMAN_STORAGE_RUNROOT_NAME:&str =
+    "runroot";
+pub const PODMAN_STORAGE_DRIVER:&str =
+    "overlay";
 pub const PODMAN_ENGINE:&str =
     "podman";
 pub const FIRECRACKER_ENGINE:&str =

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -37,6 +37,7 @@ pub mod defaults;
 pub mod fetch;
 pub mod instance;
 pub mod output;
+pub mod setup;
 
 use flakes::config::get_flakes_dir;
 use flakes::user::{User, mkdir};
@@ -52,15 +53,25 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
     // In user mode only resources of the calling user are touched
     let user = usermode(&args);
 
-    init_flakes_dir(user)?;
-
     match &args.command {
+        // init
+        cli::Commands::Init { force, .. } => {
+            // The setup this command creates is a precondition
+            // for the other commands. It is therefore created
+            // before the flake registry directory is expected
+            // to exist
+            if ! setup::init(user, *force) {
+                return Ok(ExitCode::FAILURE)
+            }
+        },
         // list
         cli::Commands::List { format, .. } => {
+            init_flakes_dir(user)?;
             app::list(user, *format);
         },
         // firecracker engine
         cli::Commands::Firecracker { command, .. } => {
+            init_flakes_dir(user)?;
             match &command {
                 // pull
                 cli::Firecracker::Pull {
@@ -158,6 +169,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
         },
         // podman engine
         cli::Commands::Podman { command, .. } => {
+            init_flakes_dir(user)?;
             match &command {
                 // pull
                 cli::Podman::Pull { uri } => {
@@ -258,6 +270,7 @@ fn usermode(args: &cli::Cli) -> bool {
     a --user request from root is ignored
     !*/
     let usermode = match &args.command {
+        cli::Commands::Init { user, .. } => *user,
         cli::Commands::List { user, .. } => *user,
         cli::Commands::Firecracker { user, .. } => *user,
         cli::Commands::Podman { user, .. } => *user

--- a/flake-ctl/src/setup.rs
+++ b/flake-ctl/src/setup.rs
@@ -1,0 +1,163 @@
+//
+// Copyright (c) 2026 Marcus Schäfer
+//
+// This file is part of flake-pilot
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+use crate::defaults;
+use std::fs;
+use std::path::Path;
+use flakes::config::{get_firecracker_ids_dir, get_podman_ids_dir};
+use flakes::defaults::{FLAKES_CONFIG_USER, FLAKES_DIR_USER};
+use uzers::{get_current_uid, get_user_by_uid};
+use uzers::os::unix::UserExt;
+
+pub fn init(usermode: bool, force: bool) -> bool {
+    /*!
+    Create the user specific setup to run flake applications
+
+    The setup consists of the flakes directory of the calling
+    user, the user specific flakes configuration file and the
+    podman storage configuration the flakes of that user are
+    stored in. Files which already exist are kept unless the
+    creation is forced
+    !*/
+    if ! usermode {
+        error!("Only the user specific setup can be created");
+        error!("The system wide setup is provided with the package");
+        error!("Please call 'flake-ctl init --user' as a normal user");
+        return false
+    }
+    let home = match user_home() {
+        Some(home) => home,
+        None => {
+            error!("Failed to lookup the home directory of the caller");
+            return false
+        }
+    };
+    let flakes_dir = format!("{home}/{FLAKES_DIR_USER}");
+    let podman_dir = format!(
+        "{}/{}", flakes_dir, defaults::PODMAN_REGISTRY_NAME
+    );
+    let firecracker_dir = format!(
+        "{}/{}", flakes_dir, defaults::FIRECRACKER_REGISTRY_NAME
+    );
+    for flake_dir in [&flakes_dir, &podman_dir, &firecracker_dir] {
+        if let Err(error) = fs::create_dir_all(flake_dir) {
+            error!("Failed to create {flake_dir}: {error:?}");
+            return false
+        }
+    }
+    let config_file = format!("{home}/{FLAKES_CONFIG_USER}");
+    let storage_conf = format!(
+        "{}/{}", podman_dir, defaults::PODMAN_STORAGE_CONF_NAME
+    );
+    if ! write_file(
+        &config_file, &flakes_config(&flakes_dir, &storage_conf), force
+    ) {
+        return false
+    }
+    if ! write_file(
+        &storage_conf, &podman_storage_config(&podman_dir), force
+    ) {
+        return false
+    }
+    info!("Flake registrations of this user are stored in {flakes_dir}");
+    info!("To let podman commands operate on this flake storage run:");
+    info!("export CONTAINERS_STORAGE_CONF={storage_conf}");
+    true
+}
+
+fn flakes_config(flakes_dir: &str, storage_conf: &str) -> String {
+    /*!
+    Provide the contents of the user specific flakes config file
+
+    The setup of the calling user uses its own flakes directory
+    and its own podman storage. The meta data directories of the
+    pilots are shared with the system wide setup, they store the
+    instance information of all users in private directories
+    !*/
+    let podman_ids_dir = get_podman_ids_dir(false);
+    let firecracker_ids_dir = get_firecracker_ids_dir(false);
+    format!(
+"generic:
+  flakes_dir: {flakes_dir}
+  podman_ids_dir: {podman_ids_dir}
+  firecracker_ids_dir: {firecracker_ids_dir}
+  podman_storage_conf: {storage_conf}
+"
+    )
+}
+
+fn podman_storage_config(podman_dir: &str) -> String {
+    /*!
+    Provide the contents of the podman storage config file
+    for the flake containers of the calling user
+    !*/
+    let driver = defaults::PODMAN_STORAGE_DRIVER;
+    let storage_dir = format!(
+        "{}/{}", podman_dir, defaults::PODMAN_STORAGE_NAME
+    );
+    let runroot_dir = format!(
+        "{}/{}", storage_dir, defaults::PODMAN_STORAGE_RUNROOT_NAME
+    );
+    format!(
+r#"[storage]
+driver = "{driver}"
+graphroot = "{storage_dir}"
+runroot = "{runroot_dir}"
+rootless_storage_path = "{storage_dir}"
+"#
+    )
+}
+
+fn write_file(config_file: &str, data: &str, force: bool) -> bool {
+    /*!
+    Write the given configuration file
+
+    An existing configuration file is expected to be adapted
+    by the user and is therefore not touched unless the
+    creation is forced
+    !*/
+    if Path::new(config_file).exists() && ! force {
+        info!("Keeping existing {config_file}");
+        info!("Use --force to create it from scratch");
+        return true
+    }
+    match fs::write(config_file, data) {
+        Ok(_) => {
+            info!("Created {config_file}");
+            true
+        },
+        Err(error) => {
+            error!("Failed to write {config_file}: {error:?}");
+            false
+        }
+    }
+}
+
+fn user_home() -> Option<String> {
+    /*!
+    Home directory of the user calling the program
+    !*/
+    get_user_by_uid(get_current_uid()).map(
+        |user| user.home_dir().to_string_lossy().to_string()
+    )
+}

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -224,9 +224,8 @@ fi
 /usr/share/bash-completion/completions/flake-ctl
 %doc /usr/share/man/man8/flake-pilot.8.gz
 %doc /usr/share/man/man8/flake-ctl.8.gz
+%doc /usr/share/man/man8/flake-ctl-init.8.gz
 %doc /usr/share/man/man8/flake-ctl-list.8.gz
-%doc /usr/share/man/man8/flake-ctl-firecracker-show.8.gz
-%doc /usr/share/man/man8/flake-ctl-podman-show.8.gz
 
 %post
 if [ -d /tmp/flakes ];then
@@ -244,6 +243,7 @@ fi
 %doc /usr/share/man/man8/flake-ctl-podman-pull.8.gz
 %doc /usr/share/man/man8/flake-ctl-podman-register.8.gz
 %doc /usr/share/man/man8/flake-ctl-podman-remove.8.gz
+%doc /usr/share/man/man8/flake-ctl-podman-show.8.gz
 %doc /usr/share/man/man8/podman-pilot.8.gz
 
 %files -n flake-pilot-firecracker
@@ -263,6 +263,7 @@ fi
 %doc /usr/share/man/man8/flake-ctl-firecracker-pull.8.gz
 %doc /usr/share/man/man8/flake-ctl-firecracker-remove.8.gz
 %doc /usr/share/man/man8/flake-ctl-firecracker-register.8.gz
+%doc /usr/share/man/man8/flake-ctl-firecracker-show.8.gz
 /usr/bin/firecracker-pilot
 %doc /usr/share/man/man8/firecracker-pilot.8.gz
 /usr/lib/flake-pilot/sci


### PR DESCRIPTION
So far the user mode setup requires a user to read the information from the flake-pilot man page and to create the respective directories and files in the home directory himself. This commit adds a new command to allow to perform this task. This Fixes #96