### PR TITLE
Increas scope of rsync transfer

### DIFF
--- a/common/src/defaults.rs
+++ b/common/src/defaults.rs
@@ -32,3 +32,11 @@ pub const FIRECRACKER_IDS_DIR: &str = "/tmp/flakes";
 pub const FLAKES_REGISTRY: &str = "/usr/share/flakes/storage";
 pub const FLAKES_REGISTRY_RUNROOT: &str = "/run/flakes";
 pub const PODMAN_STORAGE_CONF: &str = "/etc/flakes/storage.conf";
+// Options used for all rsync calls. Next to the archive mode
+// the ACLs (-A) and the extended attributes (-X) of the synced
+// data are preserved. The extended attributes also carry the
+// file capabilities and the security labels of a file. Without
+// them a program like ping, which relies on a capability
+// instead of the setuid permission, no longer works after
+// it was synced
+pub const RSYNC_OPTIONS: [&str; 4] = ["-a", "-v", "-A", "-X"];

--- a/common/src/io.rs
+++ b/common/src/io.rs
@@ -30,6 +30,7 @@ use std::path::Path;
 
 use uzers::get_current_uid;
 
+use crate::defaults;
 use crate::flakelog::FlakeLog;
 use crate::error::FlakeError;
 use crate::user::{User, mkdir};
@@ -176,7 +177,7 @@ impl IO {
         Sync data from source path to target path
         !*/
         let mut call = user.run("rsync");
-        call.arg("-av");
+        call.args(defaults::RSYNC_OPTIONS);
         for option in options {
             call.arg(option);
         }

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -704,7 +704,7 @@ pub fn sync_host(
     cp(temp_files_from.path().to_str().unwrap(), &files_from, User::ROOT)?;
 
     let mut call = user.run("rsync");
-    call.arg("-av");
+    call.args(flakes::defaults::RSYNC_OPTIONS);
     if ignore_missing {
         call.arg("--ignore-missing-args");
     }


### PR DESCRIPTION
Make sure extended attributes and ACLs gets transfered