### PR TITLE
Fix tap device setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,11 +321,20 @@ The proposed example works within the following requirements:
    the app ```$HOME/bin/claude``` was registered. The Firecracker pilot
    configures the VM instance to pass traffic on the TAP device named
    ```tap-claude```. If the application is called with an identifier like
-   ```claude @id```, the TAP device name ```tap-claude@id``` is used.
+   ```claude @id```, the TAP device name ```tap-claude_id``` is used.
 
    ```bash
    sudo ip tuntap add tap-claude mode tap
    ```
+
+   **_NOTE:_** The kernel only accepts interface names shorter than 16
+   characters which do not contain ```/```, ```:``` or whitespace. Thus
+   the pilot replaces all characters outside of ```[A-Za-z0-9_]``` by
+   ```_``` and shortens names that are too long. A shortened name keeps
+   the first characters of the app name and is made unique again by a
+   hash suffix, e.g the app ```some-very-long-application-name``` uses
+   the TAP device ```tap-some_bbb9de```. Run the app with
+   ```PILOT_DEBUG=1``` to see the TAP device name it expects.
 
    **_NOTE:_** If the TAP device does not exist, `firecracker-pilot` will
    create it for you. However, this may be too late in the case of, for example, a

--- a/README.md
+++ b/README.md
@@ -317,6 +317,46 @@ The proposed example works within the following requirements:
    to ```man dracut.cmdline``` and look up the section
    about ```ip=```.
 
+   As every instance of the app needs its own IP address, the
+   ```boot_args``` can also be set per instance. The optional
+   ```instance``` section is keyed by the ```@NAME``` selector
+   used to call the app:
+
+   ```yaml
+   vm:
+     runtime:
+       firecracker:
+         boot_args:
+           - ip=dhcp
+           - rd.route=172.16.0.1/24::eth0
+           - nameserver=8.8.8.8
+         instance:
+           "@id1":
+             boot_args:
+               - ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off
+           "@id2":
+             boot_args:
+               - ip=172.16.0.3::172.16.0.1:255.255.255.0::eth0:off
+   ```
+
+   With this setup ```claude @id1``` boots with the static
+   IP 172.16.0.2 and ```claude @id2``` with 172.16.0.3, while
+   ```claude``` without a selector still uses DHCP.
+
+   The instance settings do not replace the global ```boot_args```
+   but are merged into them: an option which is also set in the
+   ```instance``` section takes the place of the global setting
+   of the same option, options which are not set globally are
+   appended. In the example above only the ```ip=``` option is
+   exchanged, ```rd.route=``` and ```nameserver=``` stay in
+   effect for all instances.
+
+   **_NOTE:_** The ```@``` character is reserved in YAML, therefore
+   the key has to be quoted. For convenience the plain name without
+   the ```@``` prefix, e.g ```id1```, is accepted as a key as well.
+   Run the app with ```PILOT_DEBUG=1``` to see whether an instance
+   section was found and which kernel commandline it produced.
+
 4. Create a TAP device matching the app registration. In the above example,
    the app ```$HOME/bin/claude``` was registered. The Firecracker pilot
    configures the VM instance to pass traffic on the TAP device named
@@ -361,8 +401,9 @@ The proposed example works within the following requirements:
    ```
 
    **_NOTE:_** The TAP device cannot be shared across multiple instances.
-   Each instance needs its own TAP device. Thus, steps 3, 4, and 5 need
-   to be repeated for each instance.
+   Each instance needs its own TAP device. Thus, steps 4 and 5 need to
+   be repeated for each instance, and each instance needs its own
+   ```instance``` section as shown in step 3.
 
 ## Application Setup <a name="setup"/>
 

--- a/common/src/lookup.rs
+++ b/common/src/lookup.rs
@@ -64,6 +64,19 @@ impl Lookup {
         run
     }
 
+    pub fn get_instance_name() -> String {
+        /*!
+        Provide the instance name given via the @NAME pilot argument
+
+        The special @NAME argument is not passed to the actual call
+        and can be used to run different instances of the same
+        application. If more than one @NAME argument is given they
+        are concatenated in the order of appearance. If no @NAME
+        argument is given an empty string is returned
+        !*/
+        env::args().skip(1).filter(|arg| arg.starts_with('@')).collect()
+    }
+
     pub fn is_safe_instance_name(name: &str) -> bool {
         /*!
         Check the given @NAME pilot argument

--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -106,6 +106,21 @@ can be set for the firecracker engine:
           # Optional path to initrd image done by app registration
           initrd_path: /var/lib/firecracker/images/NAME/initrd
 
+          # Optional instance specific settings, keyed by the
+          # @NAME selector used to call the app. The '@' character
+          # is reserved in YAML, thus the key has to be quoted. For
+          # convenience the plain name without the '@' prefix is
+          # accepted as a key as well
+          instance:
+            "@id":
+              # Boot arguments effective for this instance only.
+              # They are merged into the boot_args above: an option
+              # which is also set here takes the place of the global
+              # setting of the same option, options which are not
+              # set globally are appended
+              boot_args:
+                - "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off"
+
 After reading of the app configuration information the application
 will be called using the configured engine. If no runtime
 arguments exists, the following defaults will apply:

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -24,8 +24,10 @@
 use lazy_static::lazy_static;
 use serde::Deserialize;
 use strum::Display;
+use std::collections::HashMap;
 use std::{env, fs, path::Path, path::PathBuf};
 use flakes::config::get_flakes_dir;
+use flakes::lookup::Lookup;
 
 lazy_static! {
     static ref CONFIG: Config<'static> = load_config();
@@ -214,6 +216,105 @@ pub struct EngineSection<'a> {
     pub initrd_path: Option<&'a str>,
 
     pub boot_args: Vec<&'a str>,
+
+    /// Optional instance specific settings. The map is keyed by
+    /// the @NAME instance selector given at call time. As the '@'
+    /// character is reserved in YAML the key has to be quoted.
+    /// For convenience the plain NAME without the '@' prefix is
+    /// accepted as a key as well
+    #[serde(default)]
+    pub instance: Option<HashMap<String, InstanceSection<'a>>>,
+}
+
+impl<'a> EngineSection<'a> {
+    pub fn get_boot_args(&self, instance_name: &str) -> Vec<&'a str> {
+        /*!
+        Provide the boot_args to use for the given instance
+
+        The boot_args of the engine section are the base. An option
+        which is also set in the instance section of instance_name
+        takes the place of the global setting of the same option.
+        Options which are not set globally are appended. If there
+        is no section for instance_name the global boot_args are
+        used unchanged
+        !*/
+        let instance_boot_args = self.get_instance_boot_args(instance_name);
+        if instance_boot_args.is_empty() {
+            return self.boot_args.clone()
+        }
+        let instance_keys: Vec<&str> = instance_boot_args.iter()
+            .map(|boot_arg| boot_arg_name(boot_arg)).collect();
+
+        let mut boot_args: Vec<&'a str> = Vec::new();
+        let mut applied: Vec<&str> = Vec::new();
+        for boot_arg in &self.boot_args {
+            let name = boot_arg_name(boot_arg);
+            if ! instance_keys.contains(&name) {
+                boot_args.push(boot_arg);
+                continue
+            }
+            // the instance setting(s) of this option take the
+            // place of the global setting
+            if ! applied.contains(&name) {
+                applied.push(name);
+                boot_args.extend(
+                    instance_boot_args.iter()
+                        .filter(|arg| boot_arg_name(arg) == name)
+                );
+            }
+        }
+        // options which are not set globally are appended
+        for (boot_arg, name) in instance_boot_args.iter().zip(&instance_keys) {
+            if ! applied.contains(name) {
+                boot_args.push(boot_arg);
+            }
+        }
+        boot_args
+    }
+
+    fn get_instance_boot_args(&self, instance_name: &str) -> Vec<&'a str> {
+        /*!
+        Provide the boot_args configured for the given instance
+        !*/
+        let instances = match self.instance.as_ref() {
+            Some(instances) => instances,
+            None => return Vec::new()
+        };
+        let instance_section = instances.get(instance_name).or_else(
+            || instances.get(instance_name.trim_start_matches('@'))
+        );
+        match instance_section {
+            Some(instance_section) => {
+                if Lookup::is_debug() {
+                    debug!("Using boot_args of instance {instance_name}");
+                }
+                instance_section.boot_args.clone().unwrap_or_default()
+            },
+            None => {
+                if Lookup::is_debug() && ! instance_name.is_empty() {
+                    debug!("No boot_args configured for {instance_name}");
+                }
+                Vec::new()
+            }
+        }
+    }
+}
+
+fn boot_arg_name(boot_arg: &str) -> &str {
+    /*!
+    Provide the option name of a kernel boot argument
+
+    The name is the part in front of the first '=' character.
+    Boot arguments without a value, e.g 'quiet', are their own name
+    !*/
+    boot_arg.split('=').next().unwrap_or(boot_arg)
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+pub struct InstanceSection<'a> {
+    /// Boot arguments effective for this instance only
+    #[serde(borrow, default)]
+    pub boot_args: Option<Vec<&'a str>>,
 }
 
 #[derive(Default, Debug, Deserialize, Clone, Display)]

--- a/firecracker-pilot/src/defaults.rs
+++ b/firecracker-pilot/src/defaults.rs
@@ -42,6 +42,14 @@ pub const FIRECRACKER_TEMPLATE:&str =
     "/etc/flakes/firecracker.json";
 pub const FIRECRACKER_VSOCK_PREFIX: &str =
     "sci_cmd_";
+pub const TAP_DEVICE_PREFIX: &str =
+    "tap-";
+// Max. size of a network interface name including the
+// terminating zero byte as defined by IFNAMSIZ in linux/if.h
+pub const IFNAMSIZ: usize = 16;
+// Number of hex digits used to make shortened
+// network interface names unique
+pub const IFNAME_HASH_LEN: usize = 6;
 pub const FIRECRACKER_VSOCK_PORT_START: u32 = 49200;
 pub const GC_THRESHOLD: usize = 1;
 pub const TERM_NAME_MAX_LEN: usize = 32;

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -757,34 +757,42 @@ pub fn create_firecracker_config(
     }
 
     // set tap device name
-    let tapname = format!("tap-{}", get_meta_name(program_name));
-    firecracker_config.network_interfaces[0].host_dev_name = tapname.clone();
-    // create tap device if not present
-    let mut taplist = Command::new("ip");
-    taplist.arg("tuntap").arg("list");
-    if Lookup::is_debug() {
-        debug!("{:?} {:?}", taplist.get_program(), taplist.get_args());
-    }
-    let output = taplist.output()?;
-    let mut tap_devices = String::new();
-    tap_devices.push_str(
-        &String::from_utf8_lossy(&output.stdout)
-    );
-    let tap_matching =
-        tap_devices.lines().find(|line| line.starts_with(&tapname));
-    if tap_matching.is_none() {
-        let root_user = User::from("root");
-        let mut tap = root_user.run("ip");
-        tap
-            .arg("tuntap")
-            .arg("add")
-            .arg(tapname)
-            .arg("mode")
-            .arg("tap");
+    if firecracker_config.network_interfaces.is_empty() {
         if Lookup::is_debug() {
-            debug!("{:?} {:?}", tap.get_program(), tap.get_args());
+            debug!("No network interface configured, skipping tap setup");
         }
-        tap.perform()?;
+    } else {
+        let tapname = get_tap_name(program_name);
+        if Lookup::is_debug() {
+            debug!("tap device is {tapname}");
+        }
+        firecracker_config.network_interfaces[0].host_dev_name =
+            tapname.clone();
+        // create tap device if not present
+        let mut taplist = Command::new("ip");
+        taplist.arg("tuntap").arg("list");
+        if Lookup::is_debug() {
+            debug!("{:?} {:?}", taplist.get_program(), taplist.get_args());
+        }
+        let output = taplist.output()?;
+        let tap_devices = String::from_utf8_lossy(&output.stdout);
+        let tap_exists = tap_devices.lines().any(
+            |line| get_tuntap_device_name(line) == tapname
+        );
+        if ! tap_exists {
+            let root_user = User::from("root");
+            let mut tap = root_user.run("ip");
+            tap
+                .arg("tuntap")
+                .arg("add")
+                .arg(&tapname)
+                .arg("mode")
+                .arg("tap");
+            if Lookup::is_debug() {
+                debug!("{:?} {:?}", tap.get_program(), tap.get_args());
+            }
+            tap.perform()?;
+        }
     }
 
     // set vsock name
@@ -930,6 +938,86 @@ pub fn get_meta_name(program_name: &String) -> String {
         }
     }
     meta_file
+}
+
+pub fn get_tap_name(program_name: &String) -> String {
+    /*!
+    Construct the name of the TAP device for the given program name
+    !*/
+    get_valid_interface_name(
+        defaults::TAP_DEVICE_PREFIX, &get_meta_name(program_name)
+    )
+}
+
+pub fn get_valid_interface_name(prefix: &str, name: &str) -> String {
+    /*!
+    Construct a valid network interface name from prefix and name
+
+    The name of a flake is a free form string, e.g the basename of
+    the calling program optionally extended by the @NAME instance
+    selector. The kernel on the other hand only accepts interface
+    names which are shorter than IFNAMSIZ and which do not contain
+    '/', ':' or whitespace. In addition tools like iproute2 use
+    the '@' character to report the parent of an interface and
+    therefore can't handle it as part of a name.
+
+    Thus all characters outside of [A-Za-z0-9_] are replaced by '_'
+    and names that are too long are shortened. To keep shortened
+    names unique they are suffixed with a hash of the original name
+    !*/
+    let name_size = defaults::IFNAMSIZ - 1 - prefix.len();
+    let mut interface_name = String::new();
+    for letter in name.chars() {
+        if letter.is_ascii_alphanumeric() || letter == '_' {
+            interface_name.push(letter)
+        } else {
+            interface_name.push('_')
+        }
+    }
+    if interface_name.len() > name_size || interface_name.is_empty() {
+        let hash_size = defaults::IFNAME_HASH_LEN;
+        let short_name: String = interface_name.chars().take(
+            name_size.saturating_sub(hash_size + 1)
+        ).collect();
+        interface_name = format!(
+            "{}_{:0width$x}",
+            short_name,
+            name_hash(name) & ((1 << (4 * hash_size)) - 1),
+            width = hash_size
+        );
+    }
+    format!("{prefix}{interface_name}")
+}
+
+fn name_hash(name: &str) -> u64 {
+    /*!
+    FNV-1a hash of the given name
+
+    Used to keep shortened interface names unique. An own
+    implementation is used because the result must stay the
+    same across program calls and rust versions, which the
+    hashers from the standard library do not guarantee
+    !*/
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in name.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    hash
+}
+
+fn get_tuntap_device_name(tuntap_list_line: &str) -> &str {
+    /*!
+    Read the device name from a line of the 'ip tuntap list' output
+
+    The expected format of a line is: 'NAME: tun|tap FLAGS...'.
+    For devices attached to a parent device the name is reported
+    in the 'NAME@PARENT' notation
+    !*/
+    tuntap_list_line
+        .split(':').next().unwrap_or_default()
+        .split('@').next().unwrap_or_default()
+        .trim()
 }
 
 pub fn gc_meta_files(

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -167,6 +167,15 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
           # Optional path to initrd image done by app registration
           initrd_path: /var/lib/firecracker/images/NAME/initrd
 
+          # Optional instance specific settings, keyed by the
+          # @NAME instance selector. A boot_args option set here
+          # replaces the global setting of the same option for
+          # this instance. Options not set globally are appended
+          instance:
+            "@id":
+              boot_args:
+                - "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off"
+
       include:
         tar:
           - tar-archive-file-name-to-include
@@ -702,7 +711,7 @@ pub fn create_firecracker_config(
     // that interactive commands, e.g a shell, can provide features
     // like tab completion
     boot_args.append(&mut get_terminal_boot_args());
-    for boot_option in engine_section.boot_args
+    for boot_option in engine_section.get_boot_args(&Lookup::get_instance_name())
     {
         if (resume || force_vsock)
             && ! Lookup::is_debug()

--- a/firecracker-pilot/src/tests.rs
+++ b/firecracker-pilot/src/tests.rs
@@ -24,6 +24,8 @@
 //
 use crate::config::config_file;
 use crate::config::config_from_str;
+use crate::defaults;
+use crate::firecracker::get_valid_interface_name;
 
 #[test]
 fn simple_config() {
@@ -58,4 +60,70 @@ vm:
 fn test_program_config_file() {
     let config_file = config_file("app", false);
     assert_eq!("/usr/share/flakes/app.yaml", config_file);
+}
+
+fn is_valid_interface_name(name: &str) -> bool {
+    // conditions taken from dev_valid_name() in the kernel,
+    // extended by the '@' character which iproute2 uses to
+    // report the parent of an interface
+    ! name.is_empty()
+        && name.len() < defaults::IFNAMSIZ
+        && name != "."
+        && name != ".."
+        && ! name.chars().any(
+            |letter| letter == '/'
+                || letter == ':'
+                || letter == '@'
+                || letter.is_whitespace()
+        )
+}
+
+#[test]
+fn test_tap_name_is_kept_if_valid() {
+    assert_eq!("tap-app", get_valid_interface_name("tap-", "app"));
+}
+
+#[test]
+fn test_tap_name_replaces_invalid_characters() {
+    assert_eq!("tap-app_id", get_valid_interface_name("tap-", "app@id"));
+    assert_eq!("tap-a_b_c_d", get_valid_interface_name("tap-", "a/b:c d"));
+}
+
+#[test]
+fn test_tap_name_is_shortened() {
+    let name = get_valid_interface_name(
+        "tap-", "some-very-long-application-name"
+    );
+    assert_eq!("tap-some_bbb9de", name);
+    assert!(is_valid_interface_name(&name));
+}
+
+#[test]
+fn test_tap_name_of_long_names_stays_unique() {
+    let name_a = get_valid_interface_name(
+        "tap-", "some-very-long-application-name@a"
+    );
+    let name_b = get_valid_interface_name(
+        "tap-", "some-very-long-application-name@b"
+    );
+    assert_ne!(name_a, name_b);
+}
+
+#[test]
+fn test_tap_name_of_empty_name_is_valid() {
+    assert!(is_valid_interface_name(&get_valid_interface_name("tap-", "")));
+}
+
+#[test]
+fn test_tap_name_is_valid_for_arbitrary_names() {
+    for name in [
+        "", ".", "..", "app", "app@id", "/usr/bin/app", "sömé äpp",
+        "abcdefghijkl", "@", "0123456789012345678901234567890123456789"
+    ] {
+        let interface_name = get_valid_interface_name("tap-", name);
+        assert!(
+            is_valid_interface_name(&interface_name),
+            "invalid interface name {} from {}", interface_name, name
+        );
+    }
 }

--- a/firecracker-pilot/src/tests.rs
+++ b/firecracker-pilot/src/tests.rs
@@ -56,6 +56,86 @@ vm:
     assert_eq!(cfg.vm.name, "Dio");
 }
 
+fn instance_engine_section() -> crate::config::EngineSection<'static> {
+    // Leaked to make the borrow of the parsed config static, the
+    // same way the config singleton in config.rs is set up
+    let config = Box::leak(Box::new(config_from_str(
+            r#"vm:
+ name: JoJo
+ host_app_path: /myapp
+ runtime:
+  runas: root
+  firecracker:
+   rootfs_image_path: /rootfs
+   kernel_image_path: /kernel
+   boot_args:
+     - "init=/usr/sbin/sci"
+     - "root=/dev/vda"
+     - "ip=dhcp"
+     - "quiet"
+   instance:
+     "@one":
+       boot_args:
+         - "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off"
+         - "nameserver=8.8.8.8"
+     "two":
+       boot_args:
+         - "root=/dev/vdb"
+     "@none":
+       boot_args: ~
+include:
+ tar: ~
+"#,
+    )));
+    config.runtime().firecracker
+}
+
+#[test]
+fn test_boot_args_without_instance_are_unchanged() {
+    let engine_section = instance_engine_section();
+    assert_eq!(
+        vec!["init=/usr/sbin/sci", "root=/dev/vda", "ip=dhcp", "quiet"],
+        engine_section.get_boot_args("")
+    );
+}
+
+#[test]
+fn test_boot_args_of_unknown_instance_are_unchanged() {
+    let engine_section = instance_engine_section();
+    assert_eq!(
+        engine_section.boot_args, engine_section.get_boot_args("@other")
+    );
+    assert_eq!(
+        engine_section.boot_args, engine_section.get_boot_args("@none")
+    );
+}
+
+#[test]
+fn test_instance_boot_args_replace_and_append() {
+    let engine_section = instance_engine_section();
+    // ip= takes the place of the global ip=dhcp, the
+    // nameserver= option is not set globally and is appended
+    assert_eq!(
+        vec![
+            "init=/usr/sbin/sci",
+            "root=/dev/vda",
+            "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off",
+            "quiet",
+            "nameserver=8.8.8.8"
+        ],
+        engine_section.get_boot_args("@one")
+    );
+}
+
+#[test]
+fn test_instance_name_without_at_sign_is_accepted_as_key() {
+    let engine_section = instance_engine_section();
+    assert_eq!(
+        vec!["init=/usr/sbin/sci", "root=/dev/vdb", "ip=dhcp", "quiet"],
+        engine_section.get_boot_args("@two")
+    );
+}
+
 #[test]
 fn test_program_config_file() {
     let config_file = config_file("app", false);

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -22,6 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
+use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::path::Path;
 use serde::{Serialize, Deserialize};
@@ -88,6 +89,11 @@ pub struct AppFireCrackerEngine {
     pub mem_size_mib: Option<i32>,
     pub vcpu_count: Option<i32>,
     pub cache_type: Option<String>,
+    pub instance: Option<HashMap<String, AppFireCrackerInstance>>,
+}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AppFireCrackerInstance {
+    pub boot_args: Option<Vec<String>>,
 }
 
 impl AppConfig {

--- a/flake-ctl/template/firecracker-flake.yaml
+++ b/flake-ctl/template/firecracker-flake.yaml
@@ -27,3 +27,13 @@ vm:
       mem_size_mib: 4096
       vcpu_count: 2
       cache_type: ~
+      # Optional instance specific settings, keyed by the @NAME
+      # instance selector used to call the app. A boot_args option
+      # set here replaces the global setting of the same option for
+      # this instance. Options not set globally are appended, e.g:
+      #
+      # instance:
+      #   "@id":
+      #     boot_args:
+      #       - "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off"
+      instance: ~


### PR DESCRIPTION
The tap name is a free-form string (program basename plus the @NAME instance selector), which could produce names the kernel rejects. With this commit:

* every character outside [A-Za-z0-9_] becomes _ — covers /, :, whitespace (rejected by the kernel's dev_valid_name) and @ (kernel-legal but iproute2 uses it for the name@parent notation);

* names longer than IFNAMSIZ - 1 (15) are truncated to the leading characters and re-uniquified with a 6-hex-digit hash suffix, e.g. some-very-long-application-name → tap-some_bbb9de;

* an empty name degrades to the hash rather than producing the bare prefix.

* The tap name is logged under PILOT_DEBUG=1, so users can see which device to pre-create. Later versions might offer a network setup in flake-ctl