### PR TITLE
Fix CWE-59 / Privilege Escalation issues

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,4 +33,5 @@ pub mod config;
 pub mod flakelog;
 pub mod defaults;
 pub mod io;
+pub mod openat;
 pub mod network;

--- a/common/src/openat.rs
+++ b/common/src/openat.rs
@@ -1,0 +1,497 @@
+//
+// Copyright (c) 2023 Marcus Schäfer
+//
+// This file is part of flake-pilot
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//! File operations which never follow a symbolic link
+//!
+//! Checking a path for symbolic links and acting on it afterwards
+//! is racy. Between the check and the call the path can be replaced
+//! by a link and the call then works on a target somebody else has
+//! chosen (CWE-59). The functions in this module do not check, they
+//! resolve the path with openat2(RESOLVE_NO_SYMLINKS) and do their
+//! work on the resulting file descriptor. A descriptor stays bound
+//! to the file it was opened on and cannot be redirected.
+use std::ffi::{CStr, CString};
+use std::fs::File;
+use std::io::{Error, ErrorKind, Result};
+use std::mem;
+use std::os::unix::ffi::OsStrExt;
+use std::os::unix::io::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::path::{Component, Path};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use libc::c_int;
+
+// openat2() exists since Linux 5.6. On an older kernel the same
+// guarantee is provided by O_NOFOLLOW, see open_at()
+static NO_OPENAT2: AtomicBool = AtomicBool::new(false);
+
+pub fn create_dir_all(dirname: &str, mode: u32) -> Result<()> {
+    /*!
+    Create dirname and the missing directories above it
+
+    The mode is set on the directory dirname refers to, the
+    directories created above it get the standard mode, like
+    'mkdir -p' does it. An already existing directory keeps its
+    mode. No component of the path is allowed to be a symbolic
+    link
+    !*/
+    let (parent, name) = open_parent(dirname, true)?;
+    match make_dir_at(parent.as_raw_fd(), &name, mode) {
+        Ok(()) => {
+            // The mode given to mkdir is masked by the umask of the
+            // process, therefore it has to be set again. This is
+            // done on the descriptor of the new directory. A chmod
+            // by name could act on a link placed there in between
+            let directory = open_directory(parent.as_raw_fd(), &name)?;
+            set_mode_of(&directory, mode)
+        },
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+            // Opening the directory proves that it really is one
+            // and not a symbolic link pointing to one
+            open_directory(parent.as_raw_fd(), &name)?;
+            Ok(())
+        },
+        Err(error) => Err(error)
+    }
+}
+
+pub fn set_mode(filename: &str, mode: u32) -> Result<()> {
+    /*!
+    Set the permissions of filename
+
+    The file itself is changed, also if it is a symbolic link. No
+    component of the path is allowed to be a symbolic link
+    !*/
+    let (parent, name) = open_parent(filename, false)?;
+    // O_PATH opens any type of file, also a socket or a device
+    // which could not be opened for reading or writing
+    let target = open_at(parent.as_raw_fd(), &name, libc::O_PATH, 0)?;
+    // fchmod() does not work on a descriptor opened with O_PATH.
+    // The proc file of the descriptor refers to the file it is
+    // bound to, thus this path cannot be redirected either. It is
+    // the way glibc implements fchmodat(AT_SYMLINK_NOFOLLOW)
+    let proc_path = to_c_string(
+        &format!("/proc/self/fd/{}", target.as_raw_fd())
+    )?;
+    if unsafe { libc::chmod(proc_path.as_ptr(), mode as libc::mode_t) } != 0 {
+        return Err(Error::last_os_error())
+    }
+    Ok(())
+}
+
+pub fn copy(source: &str, target: &str) -> Result<()> {
+    /*!
+    Copy the contents of source to target
+
+    A target which does not exist yet is created with the
+    permissions of the source, an existing target keeps its own
+    permissions. Neither of the two paths is allowed to contain a
+    symbolic link, also not as its last component
+    !*/
+    let (source_dir, source_name) = open_parent(source, false)?;
+    let source_file = open_at(
+        source_dir.as_raw_fd(), &source_name, libc::O_RDONLY, 0
+    )?;
+    let source_mode = mode_of(&source_file)? & 0o7777;
+    let (target_dir, target_name) = open_parent(target, false)?;
+    let target_file = match open_at(
+        target_dir.as_raw_fd(), &target_name,
+        libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL, 0o600
+    ) {
+        Ok(created) => {
+            set_mode_of(&created, source_mode)?;
+            created
+        },
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => open_at(
+            target_dir.as_raw_fd(), &target_name,
+            libc::O_WRONLY | libc::O_TRUNC, 0
+        )?,
+        Err(error) => return Err(error)
+    };
+    std::io::copy(
+        &mut File::from(source_file), &mut File::from(target_file)
+    )?;
+    Ok(())
+}
+
+fn open_parent(path: &str, create: bool) -> Result<(OwnedFd, CString)> {
+    /*!
+    Open the directory the last component of path lives in
+
+    The path is walked component by component, each of them
+    opened relative to the one before and none of them allowed to
+    be a symbolic link. If create is set, missing directories on
+    the way are created. Provides the descriptor of the directory
+    and the name of the last component in it
+    !*/
+    let mut components = path_components(path)?;
+    let name = match components.pop() {
+        Some(name) => name,
+        None => return Err(Error::new(
+            ErrorKind::InvalidInput, format!("{path} has no name component")
+        ))
+    };
+    let start = if Path::new(path).is_absolute() { "/" } else { "." };
+    let mut directory = open_directory(
+        libc::AT_FDCWD, &to_c_string(start)?
+    )?;
+    for component in components {
+        directory = match open_directory(directory.as_raw_fd(), &component) {
+            Ok(next) => next,
+            Err(error) if create && error.kind() == ErrorKind::NotFound => {
+                // Only the directory asked for gets the requested
+                // mode, the ones above it are created the way
+                // 'mkdir -p' does it
+                match make_dir_at(directory.as_raw_fd(), &component, 0o755) {
+                    Ok(()) => {},
+                    Err(error)
+                        if error.kind() == ErrorKind::AlreadyExists => {},
+                    Err(error) => return Err(error)
+                }
+                open_directory(directory.as_raw_fd(), &component)?
+            },
+            Err(error) => return Err(error)
+        }
+    }
+    Ok((directory, name))
+}
+
+fn path_components(path: &str) -> Result<Vec<CString>> {
+    /*!
+    Split path into its name components
+
+    A '..' component is rejected. Resolving it would mean to walk
+    back to a directory the process has passed already, which
+    cannot be done without trusting the path
+    !*/
+    let mut components = Vec::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::RootDir | Component::CurDir => continue,
+            Component::Normal(name) => components.push(
+                CString::new(name.as_bytes()).map_err(
+                    |_| Error::new(
+                        ErrorKind::InvalidInput,
+                        format!("{path} contains a null byte")
+                    )
+                )?
+            ),
+            _ => return Err(Error::new(
+                ErrorKind::InvalidInput,
+                format!("{path} contains a '..' component")
+            ))
+        }
+    }
+    Ok(components)
+}
+
+fn open_directory(dirfd: RawFd, name: &CStr) -> Result<OwnedFd> {
+    /*!
+    Open the directory name below the directory dirfd refers to
+    !*/
+    open_at(dirfd, name, libc::O_DIRECTORY | libc::O_RDONLY, 0)
+}
+
+fn open_at(
+    dirfd: RawFd, name: &CStr, flags: c_int, mode: u32
+) -> Result<OwnedFd> {
+    /*!
+    Open name below the directory dirfd refers to
+
+    The name must be a single path component. It is not followed
+    if it is a symbolic link, the call fails in this case
+    !*/
+    if ! NO_OPENAT2.load(Ordering::Relaxed) {
+        // The struct is not constructed as a literal because libc
+        // marks it as non exhaustive, the kernel may add fields
+        let mut how: libc::open_how = unsafe { mem::zeroed() };
+        how.flags = (flags | libc::O_CLOEXEC) as u64;
+        if flags & libc::O_CREAT != 0 {
+            how.mode = mode as u64;
+        }
+        how.resolve = libc::RESOLVE_NO_SYMLINKS;
+        let descriptor = unsafe {
+            libc::syscall(
+                libc::SYS_openat2, dirfd, name.as_ptr(),
+                &how, mem::size_of::<libc::open_how>()
+            )
+        };
+        if descriptor >= 0 {
+            return Ok(unsafe { OwnedFd::from_raw_fd(descriptor as RawFd) })
+        }
+        let error = Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ENOSYS) {
+            return Err(error)
+        }
+        NO_OPENAT2.store(true, Ordering::Relaxed);
+    }
+    // The kernel is too old for openat2(). As name is a single
+    // component below an already resolved directory, O_NOFOLLOW
+    // provides the same guarantee
+    let descriptor = unsafe {
+        libc::openat(
+            dirfd, name.as_ptr(),
+            flags | libc::O_CLOEXEC | libc::O_NOFOLLOW, mode as libc::c_uint
+        )
+    };
+    if descriptor < 0 {
+        return Err(Error::last_os_error())
+    }
+    let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+    if flags & libc::O_PATH != 0
+        && mode_of(&descriptor)? & libc::S_IFMT == libc::S_IFLNK
+    {
+        // O_NOFOLLOW does not reject a link if it is combined with
+        // O_PATH, it opens the link itself
+        return Err(Error::from_raw_os_error(libc::ELOOP))
+    }
+    Ok(descriptor)
+}
+
+fn make_dir_at(dirfd: RawFd, name: &CStr, mode: u32) -> Result<()> {
+    /*!
+    Create the directory name below the directory dirfd refers to
+    !*/
+    if unsafe {
+        libc::mkdirat(dirfd, name.as_ptr(), mode as libc::mode_t)
+    } != 0 {
+        return Err(Error::last_os_error())
+    }
+    Ok(())
+}
+
+fn set_mode_of(descriptor: &OwnedFd, mode: u32) -> Result<()> {
+    /*!
+    Set the permissions of the file the descriptor is bound to
+    !*/
+    if unsafe {
+        libc::fchmod(descriptor.as_raw_fd(), mode as libc::mode_t)
+    } != 0 {
+        return Err(Error::last_os_error())
+    }
+    Ok(())
+}
+
+fn mode_of(descriptor: &OwnedFd) -> Result<libc::mode_t> {
+    /*!
+    Provide the mode, file type and permissions, of the file the
+    descriptor is bound to
+    !*/
+    let mut attributes: libc::stat = unsafe { mem::zeroed() };
+    if unsafe {
+        libc::fstat(descriptor.as_raw_fd(), &mut attributes)
+    } != 0 {
+        return Err(Error::last_os_error())
+    }
+    Ok(attributes.st_mode)
+}
+
+fn to_c_string(name: &str) -> Result<CString> {
+    /*!
+    Convert name to the representation the kernel expects
+    !*/
+    CString::new(name.as_bytes()).map_err(
+        |_| Error::new(
+            ErrorKind::InvalidInput,
+            format!("{name} contains a null byte")
+        )
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{copy, create_dir_all, set_mode, NO_OPENAT2};
+    use std::fs;
+    use std::sync::atomic::Ordering;
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn mode_of(path: &str) -> u32 {
+        fs::symlink_metadata(path).unwrap().permissions().mode() & 0o7777
+    }
+
+    #[test]
+    fn test_create_dir_all_creates_the_path() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let dirname = format!("{base}/some/deep/dir");
+        create_dir_all(&dirname, 0o700).unwrap();
+        assert!(Path::new(&dirname).is_dir());
+        assert_eq!(0o700, mode_of(&dirname));
+        // the directories above it are not created with the mode
+        // of the directory which was asked for
+        assert_eq!(0o755, mode_of(&format!("{base}/some")));
+    }
+
+    #[test]
+    fn test_create_dir_all_sets_the_mode_despite_the_umask() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let dirname = format!("{base}/dir");
+        create_dir_all(&dirname, 0o1777).unwrap();
+        assert_eq!(0o1777, mode_of(&dirname));
+    }
+
+    #[test]
+    fn test_create_dir_all_keeps_an_existing_directory() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let dirname = format!("{base}/dir");
+        fs::create_dir(&dirname).unwrap();
+        fs::set_permissions(&dirname, fs::Permissions::from_mode(0o750))
+            .unwrap();
+        create_dir_all(&dirname, 0o700).unwrap();
+        assert_eq!(0o750, mode_of(&dirname));
+    }
+
+    #[test]
+    fn test_create_dir_all_refuses_a_symlink_in_the_path() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        fs::create_dir(format!("{base}/target")).unwrap();
+        symlink(format!("{base}/target"), format!("{base}/link")).unwrap();
+        assert!(create_dir_all(&format!("{base}/link/sub"), 0o755).is_err());
+        assert!(! Path::new(&format!("{base}/target/sub")).exists());
+        // a link as the last component is rejected as well
+        assert!(create_dir_all(&format!("{base}/link"), 0o755).is_err());
+    }
+
+    #[test]
+    fn test_create_dir_all_refuses_a_relative_path_component() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        assert!(create_dir_all(&format!("{base}/../dir"), 0o755).is_err());
+    }
+
+    #[test]
+    fn test_set_mode_changes_the_file() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let filename = format!("{base}/file");
+        fs::write(&filename, "data").unwrap();
+        set_mode(&filename, 0o600).unwrap();
+        assert_eq!(0o600, mode_of(&filename));
+    }
+
+    #[test]
+    fn test_set_mode_refuses_a_symlink() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let filename = format!("{base}/file");
+        fs::write(&filename, "data").unwrap();
+        fs::set_permissions(&filename, fs::Permissions::from_mode(0o644))
+            .unwrap();
+        symlink(&filename, format!("{base}/link")).unwrap();
+        assert!(set_mode(&format!("{base}/link"), 0o600).is_err());
+        assert!(set_mode(&format!("{base}/link/sub"), 0o600).is_err());
+        // the file the link points to was not touched
+        assert_eq!(0o644, mode_of(&filename));
+    }
+
+    #[test]
+    fn test_copy_creates_the_target() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let source = format!("{base}/source");
+        let target = format!("{base}/target");
+        fs::write(&source, "data").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o640))
+            .unwrap();
+        copy(&source, &target).unwrap();
+        assert_eq!("data", fs::read_to_string(&target).unwrap());
+        assert_eq!(0o640, mode_of(&target));
+    }
+
+    #[test]
+    fn test_copy_truncates_an_existing_target() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let source = format!("{base}/source");
+        let target = format!("{base}/target");
+        fs::write(&source, "data").unwrap();
+        fs::write(&target, "some longer data").unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o600))
+            .unwrap();
+        copy(&source, &target).unwrap();
+        assert_eq!("data", fs::read_to_string(&target).unwrap());
+        // an existing target keeps its permissions
+        assert_eq!(0o600, mode_of(&target));
+    }
+
+    #[test]
+    fn test_symlink_is_refused_without_openat2() {
+        /*!
+        The fallback for a kernel older than 5.6 has to protect
+        the same way. This is the only test switching the flag.
+        Other tests running at the same time may take the
+        fallback as well, they must pass either way
+        !*/
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        create_dir_all(&format!("{base}/dir"), 0o755).unwrap();
+        // The flag is only set if the syscall returned ENOSYS.
+        // Its state proves which of the two ways was taken
+        assert!(! NO_OPENAT2.load(Ordering::Relaxed));
+        fs::create_dir(format!("{base}/target")).unwrap();
+        fs::write(format!("{base}/target/file"), "data").unwrap();
+        fs::set_permissions(
+            format!("{base}/target/file"), fs::Permissions::from_mode(0o644)
+        ).unwrap();
+        symlink(format!("{base}/target"), format!("{base}/link")).unwrap();
+        symlink(
+            format!("{base}/target/file"), format!("{base}/file_link")
+        ).unwrap();
+        NO_OPENAT2.store(true, Ordering::Relaxed);
+        let rejected = [
+            create_dir_all(&format!("{base}/link/sub"), 0o755).is_err(),
+            create_dir_all(&format!("{base}/link"), 0o755).is_err(),
+            set_mode(&format!("{base}/file_link"), 0o600).is_err(),
+            copy(&format!("{base}/file_link"), &format!("{base}/copy"))
+                .is_err()
+        ];
+        NO_OPENAT2.store(false, Ordering::Relaxed);
+        assert_eq!([true, true, true, true], rejected);
+        assert!(! Path::new(&format!("{base}/target/sub")).exists());
+        assert!(! Path::new(&format!("{base}/copy")).exists());
+        // the file behind the link kept its permissions
+        assert_eq!(0o644, mode_of(&format!("{base}/target/file")));
+    }
+
+    #[test]
+    fn test_copy_refuses_a_symlink() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let source = format!("{base}/source");
+        let secret = format!("{base}/secret");
+        fs::write(&source, "data").unwrap();
+        fs::write(&secret, "secret").unwrap();
+        symlink(&secret, format!("{base}/link")).unwrap();
+        // neither reading through a link the caller placed...
+        assert!(copy(&format!("{base}/link"), &format!("{base}/copy")).is_err());
+        assert!(! Path::new(&format!("{base}/copy")).exists());
+        // ...nor writing through it
+        assert!(copy(&source, &format!("{base}/link")).is_err());
+        assert_eq!("secret", fs::read_to_string(&secret).unwrap());
+    }
+}

--- a/common/src/user.rs
+++ b/common/src/user.rs
@@ -22,13 +22,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 //
+use std::fs;
 use std::path::Path;
 use std::{process::Command, ffi::OsStr};
 use serde::{Serialize, Deserialize};
-use crate::command::{CommandExtTrait, CommandError};
-use uzers::{get_current_uid, get_current_groupname};
+use crate::command::CommandExtTrait;
+use uzers::{get_current_uid, get_current_username, get_current_groupname};
 use crate::lookup::{Lookup};
 use crate::error::FlakeError;
+use crate::openat;
 
 #[derive(Debug, Default, Clone, Copy, Serialize, Deserialize)]
 pub struct User<'a> {
@@ -50,6 +52,25 @@ impl User<'_> {
 
     pub fn get_group_name(&self) -> String {
         get_current_groupname().unwrap().into_string().unwrap()
+    }
+
+    pub fn is_calling_user(&self) -> bool {
+        /*!
+        Check if this user is the one running this process
+
+        Work for another user has to be handed to sudo, but work
+        for the caller can be done by the process itself. This
+        allows to do it in a way which cannot be tricked into
+        following a symbolic link
+        !*/
+        match self.name {
+            // Without a name sudo is called without the --user
+            // option, which runs the command as root
+            None | Some("root") => get_current_uid() == 0,
+            Some(name) => get_current_username()
+                .map(|caller| caller == *name)
+                .unwrap_or(false)
+        }
     }
 
     pub fn get_name(&self) -> String {
@@ -120,10 +141,27 @@ pub fn exists(filename: &str, user: User) -> Result<bool, FlakeError> {
     Ok(false)
 }
 
-pub fn cp(source: &str, target: &str, user: User) -> Result<(), CommandError> {
+pub fn cp(source: &str, target: &str, user: User) -> Result<(), FlakeError> {
     /*!
-    copy filename via sudo
+    Copy source to target
+
+    Reading through a symbolic link as root provides the contents
+    of a file the caller is not allowed to read. Writing through
+    one overwrites a file of the caller's choice. Therefore no
+    link is followed, see mkdir() for the details
     !*/
+    if user.is_calling_user() {
+        return openat::copy(source, target).map_err(
+            |error| FlakeError::IOError {
+                kind: "Copy failed".to_string(),
+                message: format!(
+                    "Failed to copy {source} to {target}: {error}"
+                )
+            }
+        )
+    }
+    no_symlink_in_path(source)?;
+    no_symlink_in_path(target)?;
     let mut call = user.run("cp");
     call.arg(source).arg(target);
     if Lookup::is_debug() {
@@ -133,10 +171,24 @@ pub fn cp(source: &str, target: &str, user: User) -> Result<(), CommandError> {
     Ok(())
 }
 
-pub fn chmod(filename: &str, mode: &str, user: User) -> Result<(), CommandError> {
+pub fn chmod(filename: &str, mode: &str, user: User) -> Result<(), FlakeError> {
     /*!
-    Chmod filename via sudo
+    Set the permissions of filename
+
+    A chmod as root through a symbolic link changes the
+    permissions of the file the link points to, which is a file
+    the caller picked. Therefore no link is followed, see mkdir()
+    for the details
     !*/
+    if user.is_calling_user() {
+        return openat::set_mode(filename, octal_mode(mode)?).map_err(
+            |error| FlakeError::IOError {
+                kind: "Chmod failed".to_string(),
+                message: format!("Failed to set mode of {filename}: {error}")
+            }
+        )
+    }
+    no_symlink_in_path(filename)?;
     let mut call = user.run("chmod");
     call.arg(mode).arg(filename);
     if Lookup::is_debug() {
@@ -146,31 +198,234 @@ pub fn chmod(filename: &str, mode: &str, user: User) -> Result<(), CommandError>
     Ok(())
 }
 
-pub fn mkdir(dirname: &str, mode: &str, user: User) -> Result<(), CommandError> {
+pub fn mkdir(dirname: &str, mode: &str, user: User) -> Result<(), FlakeError> {
     /*!
-    Make directory via sudo
-    !*/
-    let mut targetdir = dirname;
+    Make directory
 
-    let workdir;
-    let origin = Path::new(&dirname);
-    if origin.is_symlink() {
-        workdir = origin.read_link().unwrap();
-        targetdir = workdir.to_str().unwrap();
+    A directory created with the privileges of another user,
+    usually root, must not be created through a symbolic link. A
+    link placed in the path by the caller would let the privileged
+    call create a directory, and set its permissions, at a
+    location that caller picked, e.g a system directory
+
+    If the directory belongs to the user running this process, it
+    is created by the process itself. Every component of the path
+    is resolved with openat2(RESOLVE_NO_SYMLINKS) and the mode is
+    set on the descriptor of the new directory. Thus there is not
+    only no link followed, there is also no moment in which the
+    path could be replaced by one
+
+    For another user the work has to be done by sudo, which
+    resolves the path on its own. In this case the path is checked
+    to be free of links before and after the call. This closes the
+    known attack but not the window between check and call
+    !*/
+    if user.is_calling_user() {
+        return openat::create_dir_all(dirname, octal_mode(mode)?).map_err(
+            |error| FlakeError::IOError {
+                kind: "Mkdir failed".to_string(),
+                message: format!("Failed to create {dirname}: {error}")
+            }
+        )
     }
-    if ! Path::new(&targetdir).exists() {
-        let mut mkdir_call = user.run("mkdir");
-        mkdir_call.arg("-p").arg("-m").arg(mode).arg(targetdir);
-        if Lookup::is_debug() {
-            debug!("{:?} {:?}", mkdir_call.get_program(), mkdir_call.get_args());
+    no_symlink_in_path(dirname)?;
+    if Path::new(dirname).exists() {
+        return Ok(())
+    }
+    let mut mkdir_call = user.run("mkdir");
+    mkdir_call.arg("-p").arg("-m").arg(mode).arg(dirname);
+    if Lookup::is_debug() {
+        debug!("{:?} {:?}", mkdir_call.get_program(), mkdir_call.get_args());
+    }
+    mkdir_call.perform()?;
+    // The mode is applied again because 'mkdir -p' only sets it on
+    // the last component of the path and not on a directory which
+    // exists already. As chmod resolves a link, the path is
+    // checked again. The directory could have been replaced by a
+    // link in the time between its creation and this call
+    no_symlink_in_path(dirname)?;
+    let mut chmod_call = user.run("chmod");
+    chmod_call.arg(mode).arg(dirname);
+    if Lookup::is_debug() {
+        debug!("{:?} {:?}", chmod_call.get_program(), chmod_call.get_args());
+    }
+    chmod_call.perform()?;
+    Ok(())
+}
+
+pub fn octal_mode(mode: &str) -> Result<u32, FlakeError> {
+    /*!
+    Convert a mode as it is given to chmod(1), e.g "755", into
+    the number the system calls expect
+    !*/
+    u32::from_str_radix(mode, 8).map_err(
+        |_| FlakeError::IOError {
+            kind: "Invalid mode".to_string(),
+            message: format!("{mode} is no octal permission mode")
         }
-        mkdir_call.perform()?;
-        let mut chmod_call = user.run("chmod");
-        chmod_call.arg(mode).arg(targetdir);
-        if Lookup::is_debug() {
-            debug!("{:?} {:?}", chmod_call.get_program(), chmod_call.get_args());
+    )
+}
+
+pub fn no_symlink_in_path(filename: &str) -> Result<(), FlakeError> {
+    /*!
+    Make sure no component of the given path is a symbolic link
+
+    A component which does not exist is no link and a component
+    which cannot be looked up is left to the privileged call. Only
+    a component which is proven to be a link is rejected
+    !*/
+    for component in Path::new(filename).ancestors() {
+        let attributes = match fs::symlink_metadata(component) {
+            Ok(attributes) => attributes,
+            Err(_) => continue
+        };
+        if attributes.file_type().is_symlink() {
+            return Err(FlakeError::IOError {
+                kind: "Insecure path".to_string(),
+                message: format!(
+                    "{} is a symbolic link, refusing to use {} through it",
+                    component.display(), filename
+                )
+            })
         }
-        chmod_call.perform()?;
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{User, chmod, cp, mkdir, no_symlink_in_path, octal_mode};
+    use std::fs;
+    use std::os::unix::fs::{symlink, PermissionsExt};
+    use std::path::Path;
+    use tempfile::tempdir;
+    use uzers::get_current_username;
+
+    fn calling_user() -> String {
+        // Work done for this user is done by the process itself
+        // and not handed over to sudo
+        get_current_username().unwrap().into_string().unwrap()
+    }
+
+    #[test]
+    fn test_path_without_symlink_is_accepted() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        fs::create_dir(format!("{base}/dir")).unwrap();
+        assert!(no_symlink_in_path(&format!("{base}/dir")).is_ok());
+        // a component which does not exist yet is created by the
+        // call and is therefore no link
+        assert!(no_symlink_in_path(&format!("{base}/dir/new/sub")).is_ok());
+    }
+
+    #[test]
+    fn test_symlink_as_last_component_is_rejected() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        fs::create_dir(format!("{base}/target")).unwrap();
+        symlink(format!("{base}/target"), format!("{base}/link")).unwrap();
+        assert!(no_symlink_in_path(&format!("{base}/link")).is_err());
+    }
+
+    #[test]
+    fn test_symlink_in_path_is_rejected() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        fs::create_dir(format!("{base}/target")).unwrap();
+        symlink(format!("{base}/target"), format!("{base}/link")).unwrap();
+        assert!(no_symlink_in_path(&format!("{base}/link/sub")).is_err());
+    }
+
+    #[test]
+    fn test_mkdir_refuses_to_create_through_a_symlink() {
+        // The link and its target stay inside the temporary
+        // directory. Thus a regression cannot create anything
+        // outside of it
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        fs::create_dir(format!("{base}/target")).unwrap();
+        symlink(format!("{base}/target"), format!("{base}/link")).unwrap();
+        let dirname = format!("{base}/link/sub");
+        // the call is rejected before any privileged command runs
+        assert!(mkdir(&dirname, "755", User::ROOT).is_err());
+        assert!(! Path::new(&format!("{base}/target/sub")).exists());
+    }
+
+    #[test]
+    fn test_mkdir_for_the_calling_user() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let dirname = format!("{base}/some/dir");
+        let user = calling_user();
+        mkdir(&dirname, "700", User::from(user.as_str())).unwrap();
+        let attributes = fs::symlink_metadata(&dirname).unwrap();
+        assert!(attributes.is_dir());
+        assert_eq!(0o700, attributes.permissions().mode() & 0o7777);
+    }
+
+    #[test]
+    fn test_chmod_refuses_a_symlink() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let filename = format!("{base}/file");
+        fs::write(&filename, "data").unwrap();
+        fs::set_permissions(&filename, fs::Permissions::from_mode(0o644))
+            .unwrap();
+        symlink(&filename, format!("{base}/link")).unwrap();
+        assert!(chmod(&format!("{base}/link"), "600", User::ROOT).is_err());
+        assert_eq!(
+            0o644,
+            fs::symlink_metadata(&filename).unwrap()
+                .permissions().mode() & 0o7777
+        );
+    }
+
+    #[test]
+    fn test_cp_refuses_a_symlink() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let source = format!("{base}/source");
+        let secret = format!("{base}/secret");
+        fs::write(&source, "data").unwrap();
+        fs::write(&secret, "secret").unwrap();
+        symlink(&secret, format!("{base}/link")).unwrap();
+        // reading through a link placed by the caller...
+        assert!(
+            cp(&format!("{base}/link"), &format!("{base}/copy"), User::ROOT)
+                .is_err()
+        );
+        assert!(! Path::new(&format!("{base}/copy")).exists());
+        // ...and writing through it are both refused
+        assert!(cp(&source, &format!("{base}/link"), User::ROOT).is_err());
+        assert_eq!("secret", fs::read_to_string(&secret).unwrap());
+    }
+
+    #[test]
+    fn test_cp_for_the_calling_user() {
+        let workdir = tempdir().unwrap();
+        let base = workdir.path().to_str().unwrap();
+        let source = format!("{base}/source");
+        let target = format!("{base}/target");
+        fs::write(&source, "data").unwrap();
+        let user = calling_user();
+        cp(&source, &target, User::from(user.as_str())).unwrap();
+        assert_eq!("data", fs::read_to_string(&target).unwrap());
+    }
+
+    #[test]
+    fn test_work_for_another_user_is_left_to_sudo() {
+        assert!(! User::from("a_user_which_does_not_exist").is_calling_user());
+        assert!(User::from(calling_user().as_str()).is_calling_user());
+        assert_eq!(
+            uzers::get_current_uid() == 0, User::ROOT.is_calling_user()
+        );
+    }
+
+    #[test]
+    fn test_octal_mode() {
+        assert_eq!(0o755, octal_mode("755").unwrap());
+        assert_eq!(0o1777, octal_mode("1777").unwrap());
+        assert!(octal_mode("u+x").is_err());
+    }
+}
+


### PR DESCRIPTION
Several methods like chmod, cp, mkdir shell out to perform the job. If this is done with root privileges a local unprivileged attacker can create a symbolic link pointing to a restricted path. As such none of this operations should allow to follow symlinks in the given path if the calling user is not the same as the one requested for the operation. In addition the combination of tools to shell out like mkdir followed by chmod is not race free. As such this commit also introduces race free implementations which are preferred if the calling user is the same as the one requested for the operation. This fixes bsc#1277029

Assisted-by: Claude:claude-opus-4-6