### PR TITLE
Add new pilot_options section to the flake config

### DIFF
--- a/common/src/lookup.rs
+++ b/common/src/lookup.rs
@@ -93,27 +93,54 @@ impl Lookup {
         )
     }
 
-    pub fn get_pilot_run_options() -> HashMap<String, String> {
+    pub fn get_pilot_run_options(
+        default_options: Vec<&str>
+    ) -> HashMap<String, String> {
         /*!
         read runtime options which are only meant to be used for the
         pilot and should not interfere with the standard arguments
         passed along to the command call. For this purpose we deviate
         from the standard Unix/Linux commandline format and treat
         options passed as %name:value to be a pilot option
+
+        The given default_options are provided by the flake
+        configuration of the application. They are read first which
+        allows to overwrite an option of the same name at call time
         !*/
-        let args: Vec<String> = env::args().collect();
         let mut pilot_options = HashMap::new();
+        for option in default_options {
+            let option = if option.starts_with('%') {
+                option.to_string()
+            } else {
+                // for convenience the option can be configured
+                // without the '%' pilot option marker
+                format!("%{option}")
+            };
+            FlakeLog::debug(&format!("Got Default Pilot Option: {option}"));
+            Self::set_pilot_option(&mut pilot_options, &option);
+        }
+        let args: Vec<String> = env::args().collect();
         for arg in &args[1..] {
             if arg.starts_with('%') {
-                let (name, value) = arg.rsplit_once(':').unwrap_or_default();
-                if name.is_empty() {
-                    pilot_options.insert(arg.to_string(), "".to_string());
-                } else {
-                    pilot_options.insert(name.to_string(), value.to_string());
-                }
+                Self::set_pilot_option(&mut pilot_options, arg);
             }
         }
         pilot_options
+    }
+
+    fn set_pilot_option(
+        pilot_options: &mut HashMap<String, String>, option: &str
+    ) {
+        /*!
+        store the given %name:value pilot option. An option given
+        without a value is stored with an empty value
+        !*/
+        let (name, value) = option.rsplit_once(':').unwrap_or_default();
+        if name.is_empty() {
+            pilot_options.insert(option.to_string(), "".to_string());
+        } else {
+            pilot_options.insert(name.to_string(), value.to_string());
+        }
     }
 
     pub fn which(command: &str) -> bool {

--- a/completion/flake-ctl
+++ b/completion/flake-ctl
@@ -25,6 +25,7 @@ __flake_ctl_firecracker_register() {
         --no-net
         --overlay-size
         --resume
+        --pilot-option
         --run-as
         --target
         --vm
@@ -98,6 +99,7 @@ __flake_ctl_podman_register() {
         --layer
         --opt
         --resume
+        --pilot-option
         --run-as
         --target
         --help

--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -78,6 +78,20 @@ can be set for the firecracker engine:
         # Default: false
         resume: true|false
 
+        # Optional pilot options in the format:
+        # - %name or %name:value
+        # Pilot options are not passed to the application call
+        # but control the behavior of firecracker-pilot. An
+        # option configured here is always effective and does
+        # not have to be given at call time. An option of the
+        # same name provided at call time takes precedence over
+        # the configured one. As the '%' character is reserved
+        # in YAML the option has to be quoted. For the list of
+        # available options see the OPTIONS section
+        # Example:
+        pilot_options:
+          - "%port:2000"
+
         firecracker:
           # Currently fixed settings through app registration
           boot_args:
@@ -130,6 +144,13 @@ of the instance except for arguments that starts with the '@'
 or '%' sign. Caller arguments of this type are only used for
 the firecracker-pilot startup itself. See the OPTIONS section
 for the available runtime options.
+
+All options listed in the OPTIONS section, except for @NAME,
+can also be set permanently for an application through the
+**pilot_options** setting of the flake configuration. Such an
+option is always effective and does not have to be given at
+call time. Passing the option at call time takes precedence
+over the configured value.
 
 The execution of the program inside of the instance (the VM)
 is managed by an extra program called `sci` and provided with

--- a/doc/flake-ctl-firecracker-register.rst
+++ b/doc/flake-ctl-firecracker-register.rst
@@ -21,6 +21,7 @@ SYNOPSIS
        --include-tar <INCLUDE_TAR>...
        --include-path <INCLUDE_PATH>...
        --no-net
+       --pilot-option <PILOT_OPTION>...
        --resume
        --force-vsock
        --overlay-size <OVERLAY_SIZE>
@@ -92,6 +93,17 @@ OPTIONS
   Size of overlay write space in bytes. Optional suffixes are:
   KiB/MiB/GiB/TiB (1024) or KB/MB/GB/TB (1000)
 
+--pilot-option <PILOT_OPTION>...
+
+  Pilot option, and optional value, in the format %name or
+  %name:value. Pilot options are not passed to the application
+  call but control the behavior of firecracker-pilot. An option
+  registered here is always effective and does not have to be
+  given at call time. Passing the option at call time takes
+  precedence over the registered value. This option can be
+  specified multiple times. For the list of available pilot
+  options please refer to the **firecracker-pilot** manual page.
+
 --resume
 
   Resume the VM from previous execution. If the VM is still running,
@@ -133,6 +145,11 @@ EXAMPLE
    $ flake-ctl firecracker register --vm NAME \
        --overlay-size 20g \
        --app /usr/bin/apt-get
+
+   $ flake-ctl firecracker register --vm NAME \
+       --app /usr/bin/apt-get \
+       --resume \
+       --pilot-option '%port:2000'
 
 AUTHOR
 ------

--- a/doc/flake-ctl-podman-register.rst
+++ b/doc/flake-ctl-podman-register.rst
@@ -26,6 +26,7 @@ SYNOPSIS
        --info
        --layer <LAYER>...
        --opt <OPT>...
+       --pilot-option <PILOT_OPTION>...
        --resume
        --target <TARGET>
 
@@ -128,6 +129,17 @@ OPTIONS
   default settings will apply. See the example section for further
   details.
 
+--pilot-option <PILOT_OPTION>...
+
+  Pilot option, and optional value, in the format %name or
+  %name:value. Pilot options are not passed to the application
+  call but control the behavior of podman-pilot. An option
+  registered here is always effective and does not have to be
+  given at call time. Passing the option at call time takes
+  precedence over the registered value. This option can be
+  specified multiple times. For the list of available pilot
+  options please refer to the **podman-pilot** manual page.
+
 --resume
 
   Resume the container from previous execution. If the container is
@@ -166,6 +178,10 @@ EXAMPLE
        --opt '\-ti' \
        --opt '\--rm' \
        --opt '\--storage-opt size=10G'
+
+   $ flake-ctl podman register --container SOME_APT_CONTAINER \
+       --app /usr/bin/apt-get \
+       --pilot-option '%ignore_missing_volume_path'
 
 AUTHOR
 ------

--- a/doc/podman-pilot.rst
+++ b/doc/podman-pilot.rst
@@ -105,6 +105,20 @@ can be set for the supported container engine:
        # Default: false
        attach: true|false
 
+       # Optional pilot options in the format:
+       # - %name or %name:value
+       # Pilot options are not passed to the application call
+       # but control the behavior of podman-pilot. An option
+       # configured here is always effective and does not have
+       # to be given at call time. An option of the same name
+       # provided at call time takes precedence over the
+       # configured one. As the '%' character is reserved in
+       # YAML the option has to be quoted. For the list of
+       # available options see the OPTIONS section
+       # Example:
+       pilot_options:
+         - "%ignore_missing_volume_path"
+
        # Caller arguments for the podman engine in the format:
        # - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE
        # For details on podman options please consult the
@@ -135,6 +149,13 @@ of the instance except for arguments that starts with the '@'
 or '%' sign. Caller arguments of this type are only used for
 the podman-pilot startup itself. See the OPTIONS section
 for the available runtime options.
+
+All options listed below, except for @NAME, can also be set
+permanently for an application through the **pilot_options**
+setting of the flake configuration. Such an option is always
+effective and does not have to be given at call time. Passing
+the option at call time takes precedence over the configured
+value.
 
 OPTIONS
 -------

--- a/doc/user_guide/container_apps.rst
+++ b/doc/user_guide/container_apps.rst
@@ -192,3 +192,31 @@ container, with two exceptions which are read by the launcher itself:
    interactive call style or ``%remove`` to delete an instance which
    was kept by ``--resume`` or ``--attach``. See ``man 8
    podman-pilot`` for the complete list.
+
+Pilot Options as Part of the Registration
+=========================================
+
+A pilot option which is always needed does not have to be typed at
+every call. ``--pilot-option`` registers it as part of the flake:
+
+.. code-block:: bash
+
+   flake-ctl podman register \
+       --app $HOME/bin/claude \
+       --target /bin/bash \
+       --container public.ecr.aws/b9k1j9y6/ai/claude:latest \
+       --opt "\--volume %HOME/ai:%HOME/ai" \
+       --pilot-option "%ignore_missing_volume_path"
+
+The option can be given more than once and is stored in the
+``pilot_options`` list of the flake configuration:
+
+.. code-block:: yaml
+
+   container:
+     runtime:
+       pilot_options:
+         - "%ignore_missing_volume_path"
+
+Registered options are read on every call. An option of the same
+name given at call time takes precedence over the registered one.

--- a/doc/user_guide/vm_apps.rst
+++ b/doc/user_guide/vm_apps.rst
@@ -135,4 +135,12 @@ Registration Options in Short
 ``--no-net``
    Register the app without a network setup.
 
+``--pilot-option``
+   A runtime option of the pilot, e.g ``%port:2000`` to bind the
+   guest to host communication of a resume flake to a port of your
+   choice. The option is stored in the ``pilot_options`` list of the
+   flake configuration and is effective on every call. The same
+   option given at call time takes precedence. The option can be
+   specified multiple times.
+
 See ``man 8 flake-ctl-firecracker-register`` for the complete list.

--- a/firecracker-pilot/src/config.rs
+++ b/firecracker-pilot/src/config.rs
@@ -131,6 +131,14 @@ impl<'a> Config<'a> {
         self.vm.runtime.as_ref().cloned().unwrap_or_default()
     }
 
+    pub fn pilot_options(&self) -> Vec<&'a str> {
+        match self.vm.runtime.as_ref() {
+            Some(runtime) => runtime.pilot_options
+                .as_ref().cloned().unwrap_or_default(),
+            None => Vec::new()
+        }
+    }
+
     pub fn tars(&self) -> Vec<&'a str> {
         self.include.tar.as_ref().cloned().unwrap_or_default()
     }
@@ -191,6 +199,17 @@ pub struct RuntimeSection<'a> {
     /// Default: false
     #[serde(default)]
     pub force_vsock: bool,
+
+    /// Optional pilot options in the format:
+    /// - %name or %name:value
+    ///
+    /// Pilot options are not passed to the application call but
+    /// control the behavior of the pilot. An option configured
+    /// here is always effective and does not have to be given
+    /// at call time. An option of the same name provided at call
+    /// time takes precedence over the configured one
+    #[serde(default)]
+    pub pilot_options: Option<Vec<&'a str>>,
 
     pub firecracker: EngineSection<'a>,
 }

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -145,6 +145,12 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
         # Default: false
         force_vsock: true|false
 
+        # Pilot options which are always effective for this
+        # application. The same options can be given at call
+        # time and then take precedence over the setting here
+        pilot_options:
+          - "%port:2000"
+
         firecracker:
           # Currently fixed settings through app registration
           boot_args:
@@ -255,7 +261,9 @@ pub fn create(program_name: &String) -> Result<(String, String), FlakeError> {
     }
 
     // Setup VM...
-    let pilot_options = Lookup::get_pilot_run_options();
+    let pilot_options = Lookup::get_pilot_run_options(
+        config().pilot_options()
+    );
     let mut spinner = None;
     if pilot_options.contains_key("%progress") {
         spinner = Some(
@@ -443,7 +451,9 @@ pub fn get_exec_port() -> u32 {
     case use the pilot call option %port:number to bind to a port
     of your choice
     !*/
-    let pilot_options = Lookup::get_pilot_run_options();
+    let pilot_options = Lookup::get_pilot_run_options(
+        config().pilot_options()
+    );
     let port: u32 = if pilot_options.contains_key("%port") {
         pilot_options["%port"].parse::<u32>().unwrap_or_default()
     } else {

--- a/firecracker-pilot/src/tests.rs
+++ b/firecracker-pilot/src/tests.rs
@@ -183,6 +183,45 @@ fn test_program_config_file() {
     assert_eq!("/usr/share/flakes/app.yaml", config_file);
 }
 
+#[test]
+fn test_configured_pilot_options() {
+    let cfg = config_from_str(
+            r#"vm:
+ name: JoJo
+ host_app_path: /myapp
+ runtime:
+  runas: root
+  pilot_options:
+    - "%port:2000"
+  firecracker:
+   rootfs_image_path: /rootfs
+   kernel_image_path: /kernel
+   boot_args:
+     - "init=/usr/sbin/sci"
+include:
+ tar: ~
+"#,
+    );
+    assert_eq!(vec!["%port:2000"], cfg.pilot_options());
+    let pilot_options = flakes::lookup::Lookup::get_pilot_run_options(
+        cfg.pilot_options()
+    );
+    assert_eq!(Some(&"2000".to_string()), pilot_options.get("%port"));
+}
+
+#[test]
+fn test_no_pilot_options_configured() {
+    let cfg = config_from_str(
+            r#"vm:
+ name: JoJo
+ host_app_path: /myapp
+include:
+ tar: ~
+"#,
+    );
+    assert!(cfg.pilot_options().is_empty());
+}
+
 fn is_valid_interface_name(name: &str) -> bool {
     // conditions taken from dev_valid_name() in the kernel,
     // extended by the '@' character which iproute2 uses to

--- a/flake-ctl/src/app.rs
+++ b/flake-ctl/src/app.rs
@@ -111,6 +111,7 @@ pub fn create_container_config(
     attach: bool,
     usermode: bool,
     opts: Option<Vec<String>>,
+    pilot_options: Option<Vec<String>>,
 ) -> bool {
     /*!
     Create app configuration for the container engine.
@@ -153,6 +154,7 @@ pub fn create_container_config(
         attach,
         Some(&current_user),
         opts,
+        pilot_options,
     ) {
         Ok(_) => true,
         Err(error) => {
@@ -176,6 +178,7 @@ pub fn create_vm_config(
     force_vsock: bool,
     includes_tar: Option<Vec<String>>,
     includes_path: Option<Vec<String>>,
+    pilot_options: Option<Vec<String>>,
     usermode: bool,
 ) -> bool {
     /*!
@@ -207,6 +210,7 @@ pub fn create_vm_config(
         force_vsock,
         includes_tar,
         includes_path,
+        pilot_options,
         usermode,
     ) {
         Ok(_) => true,

--- a/flake-ctl/src/app_config.rs
+++ b/flake-ctl/src/app_config.rs
@@ -55,6 +55,7 @@ pub struct AppContainerRuntime {
     pub runas: Option<String>,
     pub resume: Option<bool>,
     pub attach: Option<bool>,
+    pub pilot_options: Option<Vec<String>>,
     pub podman: Option<Vec<String>>,
 }
 #[derive(Debug, Serialize, Deserialize)]
@@ -77,6 +78,7 @@ pub struct AppFireCrackerRuntime {
     pub runas: Option<String>,
     pub resume: Option<bool>,
     pub force_vsock: Option<bool>,
+    pub pilot_options: Option<Vec<String>>,
     pub firecracker: Option<AppFireCrackerEngine>,
 }
 #[derive(Debug, Serialize, Deserialize)]
@@ -96,6 +98,23 @@ pub struct AppFireCrackerInstance {
     pub boot_args: Option<Vec<String>>,
 }
 
+fn normalize_pilot_options(pilot_options: &[String]) -> Vec<String> {
+    /*!
+    Provide the pilot options in the %name or %name:value format
+
+    A pilot option is marked by a leading '%' character. For
+    convenience the option can be specified without that marker
+    which is added here
+    !*/
+    pilot_options.iter().map(
+        |pilot_option| if pilot_option.starts_with('%') {
+            pilot_option.to_string()
+        } else {
+            format!("%{pilot_option}")
+        }
+    ).collect()
+}
+
 impl AppConfig {
     #[allow(clippy::too_many_arguments)]
     pub fn save_container(
@@ -112,6 +131,7 @@ impl AppConfig {
         attach: bool,
         run_as: Option<&String>,
         opts: Option<Vec<String>>,
+        pilot_options: Option<Vec<String>>,
     ) -> Result<(), GenericError> {
         /*!
         save stores an AppConfig to the given file
@@ -166,6 +186,11 @@ impl AppConfig {
                 final_opts
             );
         }
+        if let Some(pilot_options) = &pilot_options {
+            container_config.runtime.as_mut().unwrap().pilot_options = Some(
+                normalize_pilot_options(pilot_options)
+            );
+        }
 
         let config = std::fs::OpenOptions::new()
             .write(true)
@@ -190,6 +215,7 @@ impl AppConfig {
         force_vsock: bool,
         includes_tar: Option<Vec<String>>,
         includes_path: Option<Vec<String>>,
+        pilot_options: Option<Vec<String>>,
         usermode: bool,
     ) -> Result<(), GenericError> {
         /*!
@@ -227,6 +253,11 @@ impl AppConfig {
         }
         if let Some(includes_path) = &includes_path {
             yaml_config.include.path = Some(includes_path.to_vec());
+        }
+        if let Some(pilot_options) = &pilot_options {
+            vm_config.runtime.as_mut().unwrap().pilot_options = Some(
+                normalize_pilot_options(pilot_options)
+            );
         }
         if let Some(overlay_size) = overlay_size {
             vm_config.runtime.as_mut().unwrap()

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -195,6 +195,17 @@ pub enum Firecracker {
         #[clap(long, multiple = true, requires = "overlay-size")]
         include_path: Option<Vec<String>>,
 
+        /// Pilot option, and optional value, in the format
+        /// %name or %name:value. Pilot options are not passed
+        /// to the application call but control the behavior of
+        /// firecracker-pilot. An option registered here is always
+        /// effective and does not have to be given at call time.
+        /// This option can be specified multiple times. For the
+        /// list of available pilot options please consult the
+        /// firecracker-pilot manual page.
+        #[clap(long, multiple = true)]
+        pilot_option: Option<Vec<String>>,
+
         /// Force writing the registration even if a registration
         /// of the same name already exists
         #[clap(long)]
@@ -406,6 +417,17 @@ pub enum Podman {
         /// specified multiple times.
         #[clap(long, multiple = true)]
         opt: Option<Vec<String>>,
+
+        /// Pilot option, and optional value, in the format
+        /// %name or %name:value. Pilot options are not passed
+        /// to the application call but control the behavior of
+        /// podman-pilot. An option registered here is always
+        /// effective and does not have to be given at call time.
+        /// This option can be specified multiple times. For the
+        /// list of available pilot options please consult the
+        /// podman-pilot manual page.
+        #[clap(long, multiple = true)]
+        pilot_option: Option<Vec<String>>,
 
         /// Print registration information from container if provided
         #[clap(long)]

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -96,7 +96,8 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                 // register
                 cli::Firecracker::Register {
                     vm, app, target, run_as, overlay_size, no_net, resume,
-                    force_vsock, include_tar, include_path, force
+                    force_vsock, include_tar, include_path, pilot_option,
+                    force
                 } => {
                     if *force {
                         app::remove(
@@ -125,6 +126,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                                 *force_vsock,
                                 include_tar.as_ref().cloned(),
                                 include_path.as_ref().cloned(),
+                                pilot_option.as_ref().cloned(),
                                 user,
                             );
                         }
@@ -207,7 +209,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                 cli::Podman::Register {
                     container, app, target, base, check_host_dependencies,
                     layer, include_tar, include_path, resume, attach,
-                    opt, info, force
+                    opt, pilot_option, info, force
                 } => {
                     if *info {
                         podman::print_container_info(container);
@@ -241,6 +243,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                                     *attach,
                                     user,
                                     opt.as_ref().cloned(),
+                                    pilot_option.as_ref().cloned(),
                                 );
                             }
                             if ! ok {

--- a/flake-ctl/template/container-flake.yaml
+++ b/flake-ctl/template/container-flake.yaml
@@ -12,5 +12,12 @@ container:
     runas: any
     resume: false
     attach: false
+    # Optional pilot options which are always effective for this
+    # application. The same options can be given at call time and
+    # then take precedence over the setting here, e.g:
+    #
+    # pilot_options:
+    #   - "%ignore_missing_volume_path"
+    pilot_options: ~
     podman:
       - "-ti"

--- a/flake-ctl/template/firecracker-flake.yaml
+++ b/flake-ctl/template/firecracker-flake.yaml
@@ -11,6 +11,13 @@ vm:
     runas: root
     resume: false
     force_vsock: false
+    # Optional pilot options which are always effective for this
+    # application. The same options can be given at call time and
+    # then take precedence over the setting here, e.g:
+    #
+    # pilot_options:
+    #   - "%port:2000"
+    pilot_options: ~
     firecracker:
       boot_args:
         - "init=/usr/sbin/sci"

--- a/podman-pilot/src/config.rs
+++ b/podman-pilot/src/config.rs
@@ -157,6 +157,14 @@ impl<'a> Config<'a> {
         self.container.layers.as_ref().cloned().unwrap_or_default()
     }
 
+    pub fn pilot_options(&self) -> Vec<&'a str> {
+        match self.container.runtime.as_ref() {
+            Some(runtime) => runtime.pilot_options
+                .as_ref().cloned().unwrap_or_default(),
+            None => Vec::new()
+        }
+    }
+
     pub fn tars(&self) -> Vec<&'a str> {
         self.include.tar.as_ref().cloned().unwrap_or_default()
     }
@@ -232,6 +240,17 @@ pub struct RuntimeSection<'a> {
     /// Default: false
     #[serde(default)]
     pub attach: bool,
+
+    /// Optional pilot options in the format:
+    /// - %name or %name:value
+    ///
+    /// Pilot options are not passed to the application call but
+    /// control the behavior of the pilot. An option configured
+    /// here is always effective and does not have to be given
+    /// at call time. An option of the same name provided at call
+    /// time takes precedence over the configured one
+    #[serde(default)]
+    pub pilot_options: Option<Vec<&'a str>>,
 
     /// Caller arguments for the podman engine in the format:
     /// - PODMAN_OPTION_NAME_AND_OPTIONAL_VALUE

--- a/podman-pilot/src/podman.rs
+++ b/podman-pilot/src/podman.rs
@@ -107,6 +107,12 @@ pub fn create(
         # Default: false
         attach: true|false
 
+        # Pilot options which are always effective for this
+        # application. The same options can be given at call
+        # time and then take precedence over the setting here
+        pilot_options:
+          - "%ignore_missing_volume_path"
+
         podman:
           - --storage-opt size=10G
           - -ti
@@ -222,7 +228,9 @@ pub fn create(
     // Garbage collect occasionally
     gc(user)?;
 
-    let pilot_options = Lookup::get_pilot_run_options();
+    let pilot_options = Lookup::get_pilot_run_options(
+        config().pilot_options()
+    );
 
     // create the container with configured runtime arguments
     let var_pattern = Regex::new(r"%([A-Z]+)").unwrap();
@@ -539,7 +547,9 @@ pub fn start(program_name: &str, cid: &str) -> Result<(), FlakeError> {
     Start container with the given container ID
     !*/
     let RuntimeSection { resume, attach, .. } = config().runtime();
-    let pilot_options = Lookup::get_pilot_run_options();
+    let pilot_options = Lookup::get_pilot_run_options(
+        config().pilot_options()
+    );
     let is_running = container_running(cid)?;
     let is_created = container_exists(cid)?;
     let mut is_removed = false;
@@ -591,7 +601,9 @@ pub fn call_instance(
     let RuntimeSection { runas, resume, .. } = config().runtime();
 
     let usermode = runas != "root";
-    let pilot_options = Lookup::get_pilot_run_options();
+    let pilot_options = Lookup::get_pilot_run_options(
+        config().pilot_options()
+    );
     let mut interactive = false;
     if pilot_options.contains_key("%interactive") {
         interactive = true;

--- a/podman-pilot/src/tests.rs
+++ b/podman-pilot/src/tests.rs
@@ -74,3 +74,62 @@ fn test_program_config_file() {
     let config_file = config_file("app", false);
     assert_eq!("/usr/share/flakes/app.yaml", config_file);
 }
+
+fn pilot_options_config() -> crate::config::Config<'static> {
+    config_from_str(
+r#"container:
+ name: JoJo
+ host_app_path: /myapp
+ check_host_dependencies: false
+ runtime:
+  runas: root
+  pilot_options:
+    - "%ignore_missing_volume_path"
+    - "%port:2000"
+    - "remove"
+include:
+ tar: ~
+"#, false)
+}
+
+#[test]
+fn test_configured_pilot_options() {
+    let cfg = pilot_options_config();
+    assert_eq!(
+        vec!["%ignore_missing_volume_path", "%port:2000", "remove"],
+        cfg.pilot_options()
+    );
+}
+
+#[test]
+fn test_pilot_options_are_read_from_the_configuration() {
+    // an option can be configured with or without the '%' marker
+    // and is provided with the marker in both cases
+    let pilot_options = flakes::lookup::Lookup::get_pilot_run_options(
+        pilot_options_config().pilot_options()
+    );
+    assert_eq!(
+        Some(&"".to_string()),
+        pilot_options.get("%ignore_missing_volume_path")
+    );
+    assert_eq!(Some(&"2000".to_string()), pilot_options.get("%port"));
+    assert_eq!(Some(&"".to_string()), pilot_options.get("%remove"));
+}
+
+#[test]
+fn test_no_pilot_options_configured() {
+    let cfg = config_from_str(
+r#"container:
+ name: JoJo
+ host_app_path: /myapp
+ check_host_dependencies: false
+include:
+ tar: ~
+"#, false);
+    assert!(cfg.pilot_options().is_empty());
+    assert!(
+        flakes::lookup::Lookup::get_pilot_run_options(
+            cfg.pilot_options()
+        ).is_empty()
+    );
+}


### PR DESCRIPTION
Allow to specify pilot options (that are options beginning with a %) like %ignore_missing_volume_path in the flake yaml registration file. A new registration argument named --pilot-option can be used to permanently add a pilot option as part of the registration such that it does not have to be passed at the commandline. This is related to bsc#1274855