### PR TITLE
Fix firecracker network setup

### DIFF
--- a/doc/flake-ctl-firecracker-network-add.rst
+++ b/doc/flake-ctl-firecracker-network-add.rst
@@ -61,6 +61,18 @@ The command performs the following steps:
       sudo ip link set tap-<APP> up
       sudo iptables -A FORWARD -i tap-<APP> -o <OUTGOING> -j ACCEPT
 
+4. Route the address of the application to its TAP device
+
+   .. code:: bash
+
+      sudo ip route add 172.16.0.2/32 dev tap-<APP>
+
+   Every TAP device provides the same gateway address and thus
+   the same route to the private network. Without a host route
+   for the address of the application the traffic to it would be
+   sent to the device that route points to, which is not
+   necessarily the device the application is connected to
+
 As the setup changes the network configuration of the host, the
 commands are called through **sudo**. The calling user therefore
 needs the permission to run them as root.
@@ -74,8 +86,8 @@ The steps only take effect if the host is prepared for NAT
 networking. Please run **flake-ctl firecracker network init**
 first.
 
-A device, address or rule which is already present is not created
-again. This allows to call the command more than once, e.g to
+A device, address, route or rule which is already present is not
+created again. This allows to call the command more than once, e.g to
 create the setup again after a reboot of the host. Only the flake
 configuration is persistent, the setup on the host is not.
 

--- a/doc/flake-ctl-firecracker-network-remove.rst
+++ b/doc/flake-ctl-firecracker-network-remove.rst
@@ -38,8 +38,8 @@ application. All of the setup created with
 
       sudo ip tuntap del tap-<APP> mode tap
 
-   The address of the device and its link state are deleted
-   along with it
+   The address of the device, its link state and the host route
+   to the address of the application are deleted along with it
 
 3. The network setup in the flake configuration
 

--- a/doc/user_guide/firecracker_networking.rst
+++ b/doc/user_guide/firecracker_networking.rst
@@ -74,7 +74,11 @@ The traffic of an instance takes the following path:
    host itself
 
 4. The answers are recognized by connection tracking and are routed
-   back to the TAP device the connection came from
+   back to the TAP device the connection came from. As all TAP
+   devices carry the same gateway address, and with it the same
+   route to the private network, a host route of the form
+   ``172.16.0.3/32 dev tap-claude_id1`` per instance makes sure the
+   packets are delivered to the device the instance is connected to
 
 .. note::
 
@@ -119,8 +123,9 @@ Connect an Application
    flake-ctl firecracker network add --app $HOME/bin/claude
 
 Assigns a free address to the application, writes the network setup
-to its flake configuration, creates its TAP device and connects that
-device to the outgoing interface.
+to its flake configuration, creates its TAP device, connects that
+device to the outgoing interface and routes the address of the
+application to it.
 
 As every instance needs its own address and its own TAP device, the
 command has to be called for each selector the application is called
@@ -152,9 +157,9 @@ by all applications and stays in place.
 
 All commands change the network configuration of the host and
 therefore call the required ``ip`` and ``iptables`` commands through
-``sudo``. They can be called more than once: a device or a rule which
-is already there is not created twice, and one which is gone is not
-deleted again. After a reboot of the host, calling ``init`` and
+``sudo``. They can be called more than once: a device, a route or a
+rule which is already there is not created twice, and one which is
+gone is not deleted again. After a reboot of the host, calling ``init`` and
 ``add`` again restores the setup with the same addresses.
 
 The Result in the Flake Configuration

--- a/firecracker-pilot/src/firecracker.rs
+++ b/firecracker-pilot/src/firecracker.rs
@@ -394,13 +394,13 @@ pub fn start(
             // 2. Startup VM as background job and execute app through vsock
             is_blocking = false;
             call_instance(
-                &firecracker_config, &vm_id_file, is_blocking
+                program_name, &firecracker_config, &vm_id_file, is_blocking
             )?;
             execute_command_at_instance(program_name)?;
         } else {
             // 3. Startup VM and execute app
             call_instance(
-                &firecracker_config, &vm_id_file, is_blocking
+                program_name, &firecracker_config, &vm_id_file, is_blocking
             )?;
         }
     }
@@ -408,11 +408,22 @@ pub fn start(
 }
 
 pub fn call_instance(
-    config_file: &NamedTempFile, vm_id_file: &str, is_blocking: bool
+    program_name: &String, config_file: &NamedTempFile,
+    vm_id_file: &str, is_blocking: bool
 ) -> Result<(), FlakeError> {
     /*!
     Run firecracker with specified configuration
     !*/
+    // Check if there is an old UDS socket file still present.
+    // It must be deleted to allow the new firecracker process
+    // to create and connect to it
+    let vsock_uds_path = get_vsock_uds_path(program_name)?;
+    if Path::new(&vsock_uds_path).exists() {
+        if Lookup::is_debug() {
+            debug!("Deleting {vsock_uds_path} prior new firecracker call");
+        }
+        delete_file(&vsock_uds_path);
+    }
     let mut firecracker = Command::new(defaults::FIRECRACKER);
     firecracker
         .arg("--no-api")

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -132,6 +132,10 @@ pub const NETWORK_NETMASK:&str =
     "255.255.255.0";
 pub const NETWORK_PREFIX_LEN:u8 =
     24;
+// Prefix length of the host route which connects the address of
+// a single VM instance with the TAP device of that instance
+pub const NETWORK_HOST_PREFIX_LEN:u8 =
+    32;
 pub const NETWORK_DNS:&str =
     "8.8.8.8";
 // Name of the network interface inside of the VM. Firecracker

--- a/flake-ctl/src/network.rs
+++ b/flake-ctl/src/network.rs
@@ -83,7 +83,8 @@ pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
     The flake gets a free address of the private network between
     the host and the VMs written to its configuration and the TAP
     device it expects is created and routed to the outgoing
-    interface of the host setup created by init().
+    interface of the host setup created by init(). A host route
+    connects that address with that device.
 
     Each instance of an application needs its own address and its
     own TAP device. Therefore the command has to be called for
@@ -113,6 +114,11 @@ pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
 
     // 3. the route from the TAP device to the outside world
     if ! connect_tap(&flake.tap, &outgoing_interface) {
+        return false
+    }
+
+    // 4. the host route to the address of the instance
+    if ! route_address(&address, &flake.tap) {
         return false
     }
 
@@ -906,8 +912,8 @@ fn delete_tap(tap: &str) -> bool {
     /*!
     Delete the TAP device of a VM instance
 
-    The address of the device and its link state are deleted
-    along with it
+    The address of the device, its link state and the host route
+    to the instance behind it are deleted along with it
     !*/
     if ! tap_exists(tap) {
         info!("No TAP device {tap} to delete");
@@ -984,6 +990,57 @@ fn connect_tap(tap: &str, outgoing_interface: &str) -> bool {
             spec: vec!["-i", tap, "-o", outgoing_interface, "-j", "ACCEPT"]
         }
     ])
+}
+
+fn route_address(address: &Ipv4Addr, tap: &str) -> bool {
+    /*!
+    Route the address of a VM instance to its TAP device
+
+    Every TAP device provides the same gateway address of the
+    private network. The route to that network which comes with
+    it therefore points to one of the devices only and the
+    traffic to all other instances would be sent to the wrong
+    device. A host route for the address of the instance makes
+    sure it is reached through the device it is connected to
+    !*/
+    let route = format!("{address}/{}", defaults::NETWORK_HOST_PREFIX_LEN);
+    if route_exists(address, tap) {
+        info!("Keeping existing route {route} dev {tap}");
+        return true
+    }
+    info!("Adding route {route} dev {tap}...");
+    let mut call = run_as(defaults::IP_TOOL, "root");
+    call.arg("route").arg("add").arg(&route).arg("dev").arg(tap);
+    run_ok(&mut call, &format!("add route {route} dev {tap}"))
+}
+
+fn route_exists(address: &Ipv4Addr, tap: &str) -> bool {
+    /*!
+    Check if the given device already routes the given address
+
+    A host route is reported by iproute2 with the plain address,
+    the prefix length of a single host is not shown
+    !*/
+    let mut call = Command::new(defaults::IP_TOOL);
+    call.arg("-4").arg("-oneline").arg("route").arg("show").arg("dev")
+        .arg(tap);
+    let host_address = address.to_string();
+    let host_route = format!(
+        "{host_address}/{}", defaults::NETWORK_HOST_PREFIX_LEN
+    );
+    match call.output() {
+        Ok(output) => String::from_utf8_lossy(&output.stdout).lines().any(
+            |line| {
+                let destination = line.split_whitespace().next()
+                    .unwrap_or_default();
+                destination == host_address || destination == host_route
+            }
+        ),
+        Err(error) => {
+            error!("Failed to execute {}: {error:?}", defaults::IP_TOOL);
+            false
+        }
+    }
 }
 
 fn disconnect_tap(tap: &str, outgoing_interface: &str) -> bool {


### PR DESCRIPTION
Make sure a host route is added when assigning an IP address to a firecracker instance (tap device)