### PR TITLE
Add support for NFS mounts in sci

### DIFF
--- a/doc/firecracker-pilot.rst
+++ b/doc/firecracker-pilot.rst
@@ -100,6 +100,14 @@ can be set for the firecracker engine:
             - "root=/dev/vda"
             - "acpi=off"
             - "quiet"
+            # Optional NFS volume(s) to mount in the VM before the
+            # app is called, given as a comma separated list of
+            # NAME_OR_IP:/export_path:/mount_path elements. A mount
+            # point which does not exist is created. This requires
+            # a network setup for the VM and the NFS client tools
+            # in the VM image. See sci(8) for details
+            # Example:
+            - "nfs=some.host:/host/path:/local/path"
           mem_size_mib: 4096
           vcpu_count: 2
           cache_type: Writeback

--- a/doc/sci.rst
+++ b/doc/sci.rst
@@ -39,6 +39,7 @@ Available variables are:
 
     + run= command
     + overlay_root= /dev/block_device
+    + nfs= NAME_OR_IP:/export_path:/mount_path[,...]
 
 
 If provided via the overlay_root=/dev/block_device kernel boot
@@ -49,6 +50,33 @@ using the given block device for writing.
 For the overlay_root parameter to work the firecracker.json file
 needs to have a proper section with
 a record of the overlayfs on the root system.
+
+If provided via the nfs= kernel boot parameter, sci mounts the
+listed NFS volumes before the command is called. The parameter
+takes a comma separated list of volumes, each of them given as
+the name or address of the server, the path exported by that
+server and the path it is mounted on in the instance:
+
+.. code:: bash
+
+   nfs=some.host:/host/path:/local/path,some.host:/other/path:/local/other
+
+leads to the following mount calls:
+
+.. code:: bash
+
+   mount -t nfs some.host:/host/path /local/path
+   mount -t nfs some.host:/other/path /local/other
+
+A mount point which does not exist in the instance is created.
+A volume which cannot be read from the given specification, or
+which fails to mount, is skipped and the remaining volumes are
+still mounted.
+
+For the nfs parameter to work the instance needs a working
+network setup, see **flake-ctl-firecracker-network-add**(8), and
+has to provide the NFS client tools. Mounting a filesystem of
+this type requires the ``mount.nfs`` helper program.
 
 Every environment variable configurable and all options 
 regarding filesystems are stored in the firecracker.json
@@ -88,6 +116,17 @@ ENVIROMENT VARIABLES
 |                      |                   | will not be made.                |
 |                      |                   |                                  |
 +----------------------+-------------------+----------------------------------+
+|                      |                   |                                  |
+|nfs                   | NAME_OR_IP:       | NFS volume(s) to mount before    |
+|                      | /export_path:     | the command is called. More than |
+|                      | /mount_path       | one volume can be given as a     |
+|                      |                   | comma separated list. A mount    |
+|                      |                   | point which does not exist is    |
+|                      |                   | created. The instance needs a    |
+|                      |                   | working network setup and the    |
+|                      |                   | NFS client tools for this.       |
+|                      |                   |                                  |
++----------------------+-------------------+----------------------------------+
 
 FILES
 -----
@@ -102,6 +141,7 @@ sci will execute these steps in order:
     + evaluation of environment variable 'run'
     + mounting of overlay if requested
     + switching root into overlay if configured
+    + mounting of the nfs volumes if requested
     + execution of provided command
     + reboot of firecracker instance
 

--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -32,6 +32,11 @@ pub const OVERLAY_ROOT: &str = "/overlayroot/rootfs";
 pub const OVERLAY_UPPER: &str = "/overlayroot/rootfs_upper";
 pub const OVERLAY_WORK: &str = "/overlayroot/rootfs_work";
 pub const PROBE_MODULE: &str = "/sbin/modprobe";
+pub const MOUNT_TOOL: &str = "mount";
+// Filesystem type and separator of the volume specification
+// given in the nfs=... cmdline variable
+pub const NFS_FSTYPE: &str = "nfs";
+pub const NFS_VOLUME_DELIMITER: char = ',';
 pub const SYSTEMD_NETWORK_RESOLV_CONF: &str = "/run/systemd/resolve/resolv.conf";
 pub const VM_QUIT: &str = "sci_quit";
 pub const VHOST_TRANSPORT: &str = "vmw_vsock_virtio_transport";

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -65,6 +65,9 @@ fn main() {
     if provided via the overlay_root=/dev/block_device kernel boot
     parameter, sci also prepares the root filesystem as an overlay
     using the given block device for writing.
+
+    if provided via the nfs=... kernel boot parameter, sci mounts
+    the listed NFS volumes before the command is called.
     !*/
     setup_logger();
 
@@ -251,6 +254,9 @@ fn main() {
             call = Command::new(&args[0]);
         }
     };
+
+    // mount nfs volumes if requested
+    mount_nfs_volumes();
 
     // start sshd if present
     start_sshd();
@@ -1091,7 +1097,7 @@ fn move_mounts(new_root: &str) {
     Move filesystems from current root to new_root
     !*/
     // /run
-    let mut call = Command::new("mount");
+    let mut call = Command::new(defaults::MOUNT_TOOL);
     call.arg("--bind").arg("/run").arg(format!("{new_root}/run"));
     debug(&format!("EXEC: mount -> {:?}", call.get_args()));
     match call.status() {
@@ -1106,6 +1112,89 @@ fn move_mounts(new_root: &str) {
                     debug(&format!("Failed to mount /run: {error}"));
                 }
             }
+        }
+    }
+}
+
+fn mount_nfs_volumes() {
+    /*!
+    Mount the NFS volumes given in the nfs=... cmdline variable
+
+    The variable provides a comma separated list of volumes. Each
+    of them is specified in the format:
+
+    NAME_OR_IP:/export_path:/mount_path
+
+    A volume which cannot be read from the specification is
+    skipped, all other volumes are still mounted
+    !*/
+    let nfs_volumes = env::var("nfs").unwrap_or_default();
+    if nfs_volumes.is_empty() {
+        return
+    }
+    for nfs_volume in nfs_volumes.split(defaults::NFS_VOLUME_DELIMITER) {
+        let nfs_volume = nfs_volume.trim();
+        if nfs_volume.is_empty() {
+            continue
+        }
+        match get_nfs_volume(nfs_volume) {
+            Some((source, target)) => mount_nfs_volume(source, target),
+            None => {
+                debug(&format!(
+                    "Invalid nfs volume specification [skipped]: {nfs_volume}"
+                ));
+            }
+        }
+    }
+}
+
+fn get_nfs_volume(nfs_volume: &str) -> Option<(&str, &str)> {
+    /*!
+    Read source and mount point of the given NFS volume
+
+    The mount point is the last element of the specification.
+    Everything in front of it is the source of the volume, the
+    export path on the server, which contains a colon itself
+    !*/
+    let (source, target) = nfs_volume.rsplit_once(':')?;
+    if ! source.contains(':') || ! target.starts_with('/') {
+        return None
+    }
+    Some((source, target))
+}
+
+fn mount_nfs_volume(source: &str, target: &str) {
+    /*!
+    Mount the given NFS source on the given mount point
+
+    The mount point is created if it does not exist. The mount is
+    done through the mount tool of the guest because an NFS mount
+    requires the mount helper of the filesystem to be called
+    !*/
+    match fs::create_dir_all(target) {
+        Ok(_) => { },
+        Err(error) => {
+            debug(&format!("Error creating directory {target}: {error}"));
+            return
+        }
+    }
+    let mut call = Command::new(defaults::MOUNT_TOOL);
+    call.arg("-t").arg(defaults::NFS_FSTYPE).arg(source).arg(target);
+    debug(&format!(
+        "SCI CALL: {} -> {:?}", defaults::MOUNT_TOOL, call.get_args()
+    ));
+    match run_child(&mut call) {
+        Ok(status) => {
+            if status.success() {
+                debug(&format!("Mounted {source} on {target}"))
+            } else {
+                debug(&format!(
+                    "Failed to mount {source} on {target}: {status}"
+                ))
+            }
+        },
+        Err(error) => {
+            debug(&format!("Failed to mount {source} on {target}: {error}"))
         }
     }
 }
@@ -1149,5 +1238,40 @@ fn setup_logger() {
         .write_style_or("FLAKE_LOG_STYLE", "always");
 
     env_logger::init_from_env(env);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_nfs_volume;
+
+    #[test]
+    fn test_get_nfs_volume() {
+        assert_eq!(
+            get_nfs_volume("some.host:/host/path:/local/path"),
+            Some(("some.host:/host/path", "/local/path"))
+        );
+        assert_eq!(
+            get_nfs_volume("172.16.0.1:/host/path:/local/path"),
+            Some(("172.16.0.1:/host/path", "/local/path"))
+        );
+        // an IPv6 address is enclosed in brackets and can be
+        // told apart from the delimiter of the mount point
+        assert_eq!(
+            get_nfs_volume("[fd00::1]:/host/path:/local/path"),
+            Some(("[fd00::1]:/host/path", "/local/path"))
+        );
+    }
+
+    #[test]
+    fn test_get_invalid_nfs_volume() {
+        // no mount point
+        assert_eq!(get_nfs_volume("some.host:/host/path"), None);
+        // relative mount point
+        assert_eq!(get_nfs_volume("some.host:/host/path:local"), None);
+        // no export path
+        assert_eq!(get_nfs_volume("some.host:/local/path"), None);
+        assert_eq!(get_nfs_volume("/local/path"), None);
+        assert_eq!(get_nfs_volume(""), None);
+    }
 }
 


### PR DESCRIPTION
Add support for optional NFS volume(s) to mount in the VM before the app is called, given as a comma separated list of NAME_OR_IP:/export_path:/mount_path elements. A mount point which does not exist is created. This requires a network setup for the VM and the NFS client tools in the VM image. See sci(8) for details
Example: "nfs=some.host:/host/path:/local/path".
The nfs variable exists in the VM if provided as part of the firecracker guest config boot_args. There
will be follow up implementations in flake-ctl which allows to export NFS shares and add this volume setup to an instance in a similar fashion as it was done for the network support.