### PR TITLE
Implement firecracker NFS volume add/remove

### DIFF
--- a/completion/flake-ctl
+++ b/completion/flake-ctl
@@ -58,7 +58,11 @@ __flake_ctl_firecracker_volume() {
         __comp_reply_unused "--path --help"
         return 0
     fi
-    __comp_reply "help export release"
+    if [ "${COMP_WORDS[3]}" = "add" ] || [ "${COMP_WORDS[3]}" = "remove" ];then
+        __comp_reply_unused "--app --volume --instance --help"
+        return 0
+    fi
+    __comp_reply "help export release add remove"
 }
 
 __flake_ctl_show() {

--- a/doc/flake-ctl-firecracker-volume-add.rst
+++ b/doc/flake-ctl-firecracker-volume-add.rst
@@ -1,0 +1,123 @@
+FLAKE-CTL-FIRECRACKER-VOLUME-ADD(8)
+====================================
+
+NAME
+----
+
+**flake-ctl firecracker volume add** - Provide a volume to a firecracker VM application
+
+SYNOPSIS
+--------
+
+.. code:: bash
+
+   USAGE:
+       flake-ctl firecracker volume add [OPTIONS] --app <APP> --volume <VOLUME>...
+
+   OPTIONS:
+       --app <APP>
+       --volume <VOLUME>...
+       --instance <INSTANCE>
+       --help
+
+DESCRIPTION
+-----------
+
+Provide the given host path(s) to the given firecracker flake
+application through NFS. The flake configuration of the
+application is looked up from the given application path and
+receives an ``nfs=`` boot option of the form:
+
+.. code:: yaml
+
+   boot_args:
+     - nfs=172.16.0.1:/some/local/path:/some/guest/path
+
+The server the volume is mounted from is the gateway address of
+the private network between the host and the VMs. That address
+is read from the ``rd.route=`` boot option which is written to
+the flake configuration by
+**flake-ctl-firecracker-network-add**(8). The network setup
+therefore has to be created for the application, or for the
+given instance, before a volume can be added.
+
+Multiple volumes are folded into a single ``nfs=`` option as a
+comma separated list, which is the format **sci**(8) reads the
+volumes of a VM instance from.
+
+The host path of a volume also has to be exported through NFS,
+see **flake-ctl-firecracker-volume-export**(8). The application
+does not have to be running when the command is called, the
+volume becomes available the next time the instance is started.
+
+A volume which is already configured with the given guest path
+keeps the place it has in the ``nfs=`` list, only the server or
+host path part of the entry is updated if it changed. A volume
+which is not yet configured is appended to the list.
+
+As the command only modifies the flake configuration of the
+application no privileged operations are required.
+
+INSTANCES
+---------
+
+Called with the ``--instance`` option the volumes are written to
+the section of that instance and take the place of the volumes
+configured for the application itself, they are only mounted
+when the application is called with that selector. The gateway
+address is also looked up from the network setup of that
+instance, falling back to the one of the application if the
+instance has none of its own.
+
+OPTIONS
+-------
+
+--app <APP>
+
+  Absolute path of the application on the host. The application
+  has to be registered as a VM application, see
+  **flake-ctl-firecracker-register**(8), and connected to the
+  host network, see **flake-ctl-firecracker-network-add**(8)
+
+--volume <VOLUME>
+
+  A volume to provide to the application, in the format
+  ``/some/local/path:/some/guest/path``. This option can be
+  specified multiple times
+
+--instance <INSTANCE>
+
+  The ``@NAME`` instance selector the application is called
+  with. For convenience the plain name without the ``@`` prefix
+  is accepted as well
+
+FILES
+-----
+
+* /usr/share/flakes
+* $HOME/.config/flakes
+
+EXAMPLE
+-------
+
+.. code:: bash
+
+   $ flake-ctl firecracker volume export --path /some/local/path
+
+   $ flake-ctl firecracker volume add \
+         --app $HOME/bin/claude --volume /some/local/path:/some/guest/path
+
+SEE ALSO
+--------
+
+flake-ctl-firecracker-volume-remove(8), flake-ctl-firecracker-volume-export(8), flake-ctl-firecracker-network-add(8), sci(8)
+
+AUTHOR
+------
+
+Marcus Schäfer
+
+COPYRIGHT
+---------
+
+(c) 2026, Marcus Schäfer

--- a/doc/flake-ctl-firecracker-volume-remove.rst
+++ b/doc/flake-ctl-firecracker-volume-remove.rst
@@ -1,0 +1,99 @@
+FLAKE-CTL-FIRECRACKER-VOLUME-REMOVE(8)
+=======================================
+
+NAME
+----
+
+**flake-ctl firecracker volume remove** - Delete a volume from a firecracker VM application
+
+SYNOPSIS
+--------
+
+.. code:: bash
+
+   USAGE:
+       flake-ctl firecracker volume remove [OPTIONS] --app <APP> --volume <VOLUME>...
+
+   OPTIONS:
+       --app <APP>
+       --volume <VOLUME>...
+       --instance <INSTANCE>
+       --help
+
+DESCRIPTION
+-----------
+
+Delete the given volume(s) from the flake configuration of the
+given firecracker flake application. This reverts what
+**flake-ctl-firecracker-volume-add**(8) has performed. A volume
+is matched by its host and guest path, no matter which server it
+is currently provided from.
+
+The ``nfs=`` boot option is updated to no longer list the given
+volume(s). If no volume is left the option is deleted from the
+configuration such that it is left as it was before the volumes
+were added.
+
+As the command only modifies the flake configuration of the
+application no privileged operations are required. The NFS
+export of the host path, see
+**flake-ctl-firecracker-volume-release**(8), and the network
+setup, see **flake-ctl-firecracker-network-remove**(8), are not
+touched, they may still be needed by other applications or
+instances.
+
+INSTANCES
+---------
+
+Called with the ``--instance`` option only the volumes configured
+for that instance are deleted. The instance section is dropped
+along with its last volume, leaving the configuration as it was
+before the volumes were added for that instance.
+
+OPTIONS
+-------
+
+--app <APP>
+
+  Absolute path of the application on the host
+
+--volume <VOLUME>
+
+  A volume to delete from the application, in the format
+  ``/some/local/path:/some/guest/path``. This option can be
+  specified multiple times
+
+--instance <INSTANCE>
+
+  The ``@NAME`` instance selector the volumes were added for.
+  For convenience the plain name without the ``@`` prefix is
+  accepted as well
+
+FILES
+-----
+
+* /usr/share/flakes
+* $HOME/.config/flakes
+
+EXAMPLE
+-------
+
+.. code:: bash
+
+   $ flake-ctl firecracker volume remove \
+         --app $HOME/bin/claude --volume /some/local/path:/some/guest/path
+
+SEE ALSO
+--------
+
+flake-ctl-firecracker-volume-add(8), flake-ctl-firecracker-volume-release(8), flake-ctl-firecracker-network-remove(8), sci(8)
+
+AUTHOR
+------
+
+Marcus Schäfer
+
+COPYRIGHT
+---------
+
+(c) 2026, Marcus Schäfer

--- a/doc/flake-ctl.rst
+++ b/doc/flake-ctl.rst
@@ -58,7 +58,7 @@ is no option to select the mode:
 SEE ALSO
 --------
 
-podman-pilot(8), flake-ctl-init(8), flake-ctl-list(8), flake-ctl-podman-load(8), flake-ctl-podman-register(8), flake-ctl-podman-remove(8), flake-ctl-podman-show(8), firecracker-pilot(8), flake-ctl-firecracker-load(8), flake-ctl-firecracker-register(8), flake-ctl-firecracker-remove(8), flake-ctl-firecracker-show(8), flake-ctl-firecracker-network-init(8), flake-ctl-firecracker-network-add(8), flake-ctl-firecracker-network-remove(8), flake-ctl-firecracker-volume-export(8), flake-ctl-firecracker-volume-release(8)
+podman-pilot(8), flake-ctl-init(8), flake-ctl-list(8), flake-ctl-podman-load(8), flake-ctl-podman-register(8), flake-ctl-podman-remove(8), flake-ctl-podman-show(8), firecracker-pilot(8), flake-ctl-firecracker-load(8), flake-ctl-firecracker-register(8), flake-ctl-firecracker-remove(8), flake-ctl-firecracker-show(8), flake-ctl-firecracker-network-init(8), flake-ctl-firecracker-network-add(8), flake-ctl-firecracker-network-remove(8), flake-ctl-firecracker-volume-export(8), flake-ctl-firecracker-volume-release(8), flake-ctl-firecracker-volume-add(8), flake-ctl-firecracker-volume-remove(8)
 
 AUTHOR
 ------

--- a/doc/user_guide/firecracker_volumes.rst
+++ b/doc/user_guide/firecracker_volumes.rst
@@ -1,0 +1,195 @@
+.. _firecracker-volumes:
+
+====================
+Firecracker Volumes
+====================
+
+.. hint:: **Abstract**
+
+   This chapter explains how a local host path is made available
+   inside of a Firecracker VM application, which commands create and
+   delete that setup and how the result looks in the flake
+   configuration.
+
+A Firecracker VM has no way to share a directory with the host
+directly, unlike a container it does not use the host kernel and
+therefore cannot bind mount a host path into the guest. ``flake-pilot``
+bridges this gap with NFS: a local path is exported by the host and
+mounted by the guest over the private network described in
+:ref:`firecracker-networking`. The setup is created and deleted with
+the ``flake-ctl firecracker volume`` commands, no manual NFS
+configuration is needed.
+
+The setup works within the following requirements:
+
+* The application has to be connected to the host network with
+  ``flake-ctl firecracker network add``, see
+  :ref:`firecracker-networking`. The volume setup reads the gateway
+  address from that network setup.
+
+* The guest needs a working network setup at boot and has to provide
+  the NFS client tools, in particular the ``mount.nfs`` helper
+  program.
+
+Managing volumes is a two step process: a local path is exported
+through NFS once, independently of any application. It is then added
+to one or more flake instances which mount it at a path of their
+choice.
+
+Export a Local Path
+====================
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume export --path /some/local/path
+
+Writes a ``flake-pilot`` managed entry for the given path to
+``/etc/exports``, restricted to the private firecracker network
+``172.16.0.0/24``. If the ``nfs-server`` systemd service is not
+running yet it is started, otherwise the export table is reloaded so
+the new export becomes effective right away.
+
+The command expects an existing directory. As it changes a system
+wide NFS configuration, the required privileged operations are
+executed through ``sudo`` when needed. Exporting the same path again
+keeps the existing entry unchanged.
+
+Release a Local Path
+=====================
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume release --path /some/local/path
+
+Removes the ``flake-pilot`` managed NFS export entry for the given
+path from ``/etc/exports`` and restarts the ``nfs-server`` service so
+the updated export table becomes effective. Only entries previously
+managed by ``flake-pilot`` are touched, an export created by other
+means is left in place.
+
+.. note::
+
+   Releasing a path does not check whether it is still in use by a
+   flake. Remove it from every flake it was added to first, see
+   below, before releasing the export.
+
+Add a Volume to an Application
+===============================
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume add \
+       --app $HOME/bin/claude --volume /some/local/path:/some/guest/path
+
+Looks up the flake configuration of the application from its path and
+writes an ``nfs=`` boot option to it in the form:
+
+.. code-block:: text
+
+   nfs=172.16.0.1:/some/local/path:/some/guest/path
+
+The server part of the option is not configurable, it is the gateway
+address of the private network the application is connected to,
+``172.16.0.1``, read from the ``rd.route=`` boot option written by
+``flake-ctl firecracker network add``. This is why the network setup
+has to exist before a volume can be added.
+
+The ``--volume`` option can be given more than once to add several
+volumes in one call:
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume add --app $HOME/bin/claude \
+       --volume /some/local/path:/some/guest/path \
+       --volume /other/local/path:/other/guest/path
+
+As every instance needs its own volume setup if it should differ from
+the application, the command can be called with ``--instance`` as
+well:
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume add --app $HOME/bin/claude \
+       --volume /some/local/path:/some/guest/path --instance @id1
+
+The volume(s) of an instance take the place of the volumes configured
+for the application itself, they are not merged. Calling the
+application without the ``@id1`` selector still mounts the volumes
+configured globally, if any.
+
+A volume is identified by its guest path: adding a volume with a
+guest path that is already configured replaces the entry, e.g to
+point it at a different local path or, after the path was exported
+again, a different server.
+
+.. note::
+
+   The command only changes the flake configuration of the
+   application, no privileged operations are required. The local path
+   itself still has to be exported, see above, or the mount inside of
+   the guest fails.
+
+Remove a Volume From an Application
+=====================================
+
+.. code-block:: bash
+
+   flake-ctl firecracker volume remove \
+       --app $HOME/bin/claude --volume /some/local/path:/some/guest/path
+
+Reverts what ``volume add`` has performed: the matching entry is
+deleted from the ``nfs=`` boot option, and the option itself is
+deleted once no volume is left. ``--volume`` can be repeated the same
+way as with ``add``, and ``--instance`` removes the volume(s) of that
+instance only. A volume is matched by its host and guest path, no
+matter which server it is currently provided from.
+
+Removing a volume does not release its NFS export nor does it change
+the network setup, both may still be needed by other flakes or
+instances. Release the export explicitly once it is no longer used by
+any application.
+
+The Result in the Flake Configuration
+=======================================
+
+The flake configuration for the registered ``claude`` app from
+:ref:`vm-example-claude` can be found at:
+
+.. code-block:: bash
+
+   vi ~/.config/flakes/claude.yaml
+
+Adding a volume to the application and another one to its ``@id1``
+instance leads to the following settings, on top of the network setup
+from :ref:`firecracker-networking`:
+
+.. code-block:: yaml
+
+   vm:
+     runtime:
+       firecracker:
+         boot_args:
+           - ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off
+           - rd.route=172.16.0.1/24::eth0
+           - nameserver=8.8.8.8
+           - nfs=172.16.0.1:/some/local/path:/some/guest/path
+         instance:
+           "@id1":
+             boot_args:
+               - ip=172.16.0.3::172.16.0.1:255.255.255.0::eth0:off
+               - nfs=172.16.0.1:/other/local/path:/other/guest/path
+
+More than one volume of the same section is folded into a single
+``nfs=`` option as a comma separated list, which is the format the
+init process of the guest, ``sci``, reads the volumes from. It mounts
+each of them with ``mount -t nfs`` before the application is started,
+creating the guest path if it does not exist yet. A volume which
+cannot be parsed, or which fails to mount, is skipped, the remaining
+volumes are still mounted. For details refer to ``man 8 sci``.
+
+.. note::
+
+   As with the network ``instance`` section, the ``@`` character is
+   reserved in YAML and the key has to be quoted. The plain name
+   without the ``@`` prefix, e.g ``id1``, is accepted as a key as
+   well.

--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -51,6 +51,9 @@ The guide is organized as follows:
 * :ref:`firecracker-networking` explains how a virtual machine is
   connected to the outside world.
 
+* :ref:`firecracker-volumes` explains how a local host path is
+  shared with a virtual machine over NFS.
+
 * :ref:`application-setup` documents the registry layout, the flake
   configuration and the tools to inspect a running setup.
 
@@ -76,6 +79,7 @@ matter.
    container_apps
    vm_apps
    firecracker_networking
+   firecracker_volumes
    application_setup
    building_images
    troubleshooting

--- a/doc/user_guide/spelling_wordlist.txt
+++ b/doc/user_guide/spelling_wordlist.txt
@@ -3,6 +3,7 @@ Firecracker
 KIWI
 Linux
 NAT
+NFS
 OCI
 SDK
 TAP

--- a/flake-ctl/src/cli.rs
+++ b/flake-ctl/src/cli.rs
@@ -224,7 +224,7 @@ pub enum Firecracker {
         #[clap(subcommand)]
         command: Network,
     },
-    /// Manage NFS exports for firecracker volumes
+    /// Manage volumes for VM applications
     Volume {
         #[clap(subcommand)]
         command: Volume,
@@ -307,6 +307,49 @@ pub enum Volume {
         /// An absolute path on the host to remove from the NFS exports
         #[clap(long)]
         path: String,
+    },
+    /// Provide a volume to a VM application
+    Add {
+        /// An absolute path to the application on the host.
+        /// The application must be registered as a VM
+        /// application and its flake configuration gets the
+        /// volume setup written to it
+        #[clap(long)]
+        app: String,
+
+        /// A volume to provide to the application in the format
+        /// /some/local/path:/some/guest/path. The local path is
+        /// mounted on the guest path inside of the VM. This
+        /// option can be specified multiple times
+        #[clap(long, multiple = true, required = true)]
+        volume: Vec<String>,
+
+        /// The @NAME instance selector the application is
+        /// called with. The volumes are provided to that
+        /// instance only and take the place of the volumes
+        /// configured for the application itself
+        #[clap(long)]
+        instance: Option<String>,
+    },
+    /// Delete a volume from a VM application
+    Remove {
+        /// An absolute path to the application on the host.
+        /// The volume setup is deleted from the flake
+        /// configuration of the application
+        #[clap(long)]
+        app: String,
+
+        /// A volume to delete from the application in the format
+        /// /some/local/path:/some/guest/path. This option can be
+        /// specified multiple times
+        #[clap(long, multiple = true, required = true)]
+        volume: Vec<String>,
+
+        /// The @NAME instance selector the volumes were
+        /// added for. Only the volumes of that instance
+        /// are deleted
+        #[clap(long)]
+        instance: Option<String>,
     },
 }
 

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -118,6 +118,13 @@ pub const NFS_CLIENT_NETWORK:&str =
     "172.16.0.0/24";
 pub const NFS_EXPORT_OPTIONS:&str =
     "rw,sync,no_subtree_check,no_root_squash,insecure";
+// Kernel commandline option sci reads the NFS volumes of a VM
+// from. The option provides all volumes of an instance as a
+// list of NAME_OR_IP:HOST_PATH:GUEST_PATH elements
+pub const NFS_VOLUME_BOOT_ARG:&str =
+    "nfs";
+pub const NFS_VOLUME_DELIMITER:char =
+    ',';
 // Kernel switch to turn the host into a router. Required to
 // forward the traffic of a VM from its TUN/TAP device to the
 // outgoing interface of the host

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -39,6 +39,7 @@ pub mod instance;
 pub mod network;
 pub mod output;
 pub mod setup;
+pub mod volume;
 
 use flakes::config::get_flakes_dir;
 use flakes::user::{User, mkdir};
@@ -182,6 +183,20 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                         },
                         cli::Volume::Release { path } => {
                             if ! firecracker::release_volume(path) {
+                                return Ok(ExitCode::FAILURE)
+                            }
+                        },
+                        cli::Volume::Add { app, volume, instance } => {
+                            if ! volume::add(
+                                app, volume, instance.as_ref(), user
+                            ) {
+                                return Ok(ExitCode::FAILURE)
+                            }
+                        },
+                        cli::Volume::Remove { app, volume, instance } => {
+                            if ! volume::remove(
+                                app, volume, instance.as_ref(), user
+                            ) {
                                 return Ok(ExitCode::FAILURE)
                             }
                         }

--- a/flake-ctl/src/network.rs
+++ b/flake-ctl/src/network.rs
@@ -203,25 +203,8 @@ fn get_flake_network(
     application path and the TAP device is the one the pilot
     connects the instance of the application to
     !*/
-    if ! app.starts_with('/') {
-        error!("Application {app:?} must be specified with an absolute path");
-        return None
-    }
-    let app_basename = match Path::new(app).file_name() {
-        Some(app_basename) => app_basename.to_string_lossy().to_string(),
-        None => {
-            error!("Failed to read the application name from {app}");
-            return None
-        }
-    };
-    let config_file = format!(
-        "{}/{}.yaml", get_flakes_dir(usermode), app_basename
-    );
-    if ! Path::new(&config_file).exists() {
-        error!("No flake configuration found at {config_file}");
-        error!("Please register the application first");
-        return None
-    }
+    let app_basename = get_app_basename(app)?;
+    let config_file = get_flake_config_file(app, usermode)?;
     let instance = instance.map(|instance| get_instance_name(instance));
 
     // The pilot connects the VM to the TAP device named after the
@@ -235,7 +218,45 @@ fn get_flake_network(
     Some(FlakeNetwork { config_file, instance, tap })
 }
 
-fn get_instance_name(instance: &str) -> String {
+fn get_app_basename(app: &str) -> Option<String> {
+    /*!
+    Provide the name the flake configuration of the given
+    application is stored under
+    !*/
+    if ! app.starts_with('/') {
+        error!("Application {app:?} must be specified with an absolute path");
+        return None
+    }
+    match Path::new(app).file_name() {
+        Some(app_basename) => Some(app_basename.to_string_lossy().to_string()),
+        None => {
+            error!("Failed to read the application name from {app}");
+            None
+        }
+    }
+}
+
+pub fn get_flake_config_file(app: &str, usermode: bool) -> Option<String> {
+    /*!
+    Provide the path of the flake configuration of the given
+    application
+
+    The configuration is looked up from the application path in
+    the flake registry the caller operates on
+    !*/
+    let app_basename = get_app_basename(app)?;
+    let config_file = format!(
+        "{}/{}.yaml", get_flakes_dir(usermode), app_basename
+    );
+    if ! Path::new(&config_file).exists() {
+        error!("No flake configuration found at {config_file}");
+        error!("Please register the application first");
+        return None
+    }
+    Some(config_file)
+}
+
+pub fn get_instance_name(instance: &str) -> String {
     /*!
     Provide the instance selector in its '@NAME' notation
 
@@ -262,7 +283,9 @@ fn configure_flake(
     again, e.g after a reboot of the host
     !*/
     let mut yaml_config = read_flake_config(config_file)?;
-    let engine_section = get_engine_section(&mut yaml_config, config_file)?;
+    let engine_section = get_engine_section(
+        &mut yaml_config, config_file, "network"
+    )?;
 
     // An address which is already configured for this flake is
     // kept, in all other cases a free one is taken
@@ -324,7 +347,7 @@ fn configure_flake(
     Some(address)
 }
 
-fn get_instance_key(
+pub fn get_instance_key(
     instances: &HashMap<String, AppFireCrackerInstance>, instance: &str
 ) -> String {
     /*!
@@ -355,7 +378,7 @@ fn unconfigure_flake(config_file: &str, instance: Option<&str>) -> bool {
         None => return false
     };
     let engine_section = match get_engine_section(
-        &mut yaml_config, config_file
+        &mut yaml_config, config_file, "network"
     ) {
         Some(engine_section) => engine_section,
         None => return false
@@ -444,8 +467,8 @@ fn has_configured_address(engine_section: &AppFireCrackerEngine) -> bool {
     }
 }
 
-fn get_engine_section<'a>(
-    yaml_config: &'a mut AppConfig, config_file: &str
+pub fn get_engine_section<'a>(
+    yaml_config: &'a mut AppConfig, config_file: &str, setup: &str
 ) -> Option<&'a mut AppFireCrackerEngine> {
     /*!
     Provide the firecracker runtime section of the given flake
@@ -456,7 +479,7 @@ fn get_engine_section<'a>(
         .and_then(|runtime_section| runtime_section.firecracker.as_mut());
     if engine_section.is_none() {
         error!("{config_file} provides no firecracker runtime section");
-        error!("Only firecracker flakes provide a network setup");
+        error!("Only firecracker flakes provide a {setup} setup");
     }
     engine_section
 }
@@ -568,7 +591,7 @@ fn get_gateway() -> Ipv4Addr {
     )
 }
 
-fn set_boot_arg(boot_args: &mut Vec<String>, boot_arg: String) {
+pub fn set_boot_arg(boot_args: &mut Vec<String>, boot_arg: String) {
     /*!
     Set the given kernel commandline option
 
@@ -582,21 +605,21 @@ fn set_boot_arg(boot_args: &mut Vec<String>, boot_arg: String) {
     }
 }
 
-fn unset_boot_arg(boot_args: &mut Vec<String>, name: &str) {
+pub fn unset_boot_arg(boot_args: &mut Vec<String>, name: &str) {
     /*!
     Delete the kernel commandline option of the given name
     !*/
     boot_args.retain(|boot_arg| boot_arg_name(boot_arg) != name);
 }
 
-fn boot_arg_name(boot_arg: &str) -> &str {
+pub fn boot_arg_name(boot_arg: &str) -> &str {
     /*!
     Provide the name of a kernel commandline option
     !*/
     boot_arg.split('=').next().unwrap_or(boot_arg)
 }
 
-fn read_flake_config(config_file: &str) -> Option<AppConfig> {
+pub fn read_flake_config(config_file: &str) -> Option<AppConfig> {
     /*!
     Read the given flake configuration
 
@@ -620,7 +643,7 @@ fn read_flake_config(config_file: &str) -> Option<AppConfig> {
     }
 }
 
-fn write_flake_config(config_file: &str, yaml_config: &AppConfig) -> bool {
+pub fn write_flake_config(config_file: &str, yaml_config: &AppConfig) -> bool {
     /*!
     Write back the given flake configuration
     !*/

--- a/flake-ctl/src/volume.rs
+++ b/flake-ctl/src/volume.rs
@@ -1,0 +1,564 @@
+//
+// Copyright (c) 2026 Marcus Schäfer
+//
+// This file is part of flake-pilot
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+
+use crate::app_config::{AppFireCrackerEngine, AppFireCrackerInstance};
+use crate::defaults;
+use crate::network::{
+    boot_arg_name, get_engine_section, get_flake_config_file, get_instance_key,
+    get_instance_name, read_flake_config, unset_boot_arg, write_flake_config
+};
+
+pub fn add(
+    app: &str, volumes: &[String], instance: Option<&String>, usermode: bool
+) -> bool {
+    /*!
+    Add the given volumes to the flake configuration
+
+    A volume is a host path which is provided to the VM through
+    NFS. The guest mounts it from the nfs= option of its kernel
+    commandline. The server of the volume is the gateway of the
+    private network between the host and the VMs, it is read from
+    the network setup of the flake.
+
+    Called with an instance selector the volumes are added to the
+    section of that instance and are therefore only mounted if
+    the application is called with that selector
+    !*/
+    let volumes = match get_volumes(volumes) {
+        Some(volumes) => volumes,
+        None => return false
+    };
+    let config_file = match get_flake_config_file(app, usermode) {
+        Some(config_file) => config_file,
+        None => return false
+    };
+    let instance = instance.map(|instance| get_instance_name(instance));
+    let mut yaml_config = match read_flake_config(&config_file) {
+        Some(yaml_config) => yaml_config,
+        None => return false
+    };
+    let engine_section = match get_engine_section(
+        &mut yaml_config, &config_file, "volume"
+    ) {
+        Some(engine_section) => engine_section,
+        None => return false
+    };
+    let server = match get_nfs_server(
+        engine_section, instance.as_deref(), &config_file
+    ) {
+        Some(server) => server,
+        None => return false
+    };
+
+    // The volume list of an instance takes the place of the global
+    // one, the volumes of the application are not merged into it
+    let global_volumes = get_nfs_entries(
+        engine_section.boot_args.as_deref().unwrap_or_default()
+    );
+
+    let boot_args = match instance.as_deref() {
+        Some(instance) => {
+            if ! global_volumes.is_empty() {
+                warn!("The volumes of {instance} take the place of:");
+                for entry in &global_volumes {
+                    warn!("  {entry}");
+                }
+            }
+            let instances = engine_section.instance
+                .get_or_insert_with(HashMap::new);
+            let instance_key = get_instance_key(instances, instance);
+            let instance_section = instances.entry(instance_key)
+                .or_insert(AppFireCrackerInstance { boot_args: None });
+            instance_section.boot_args.get_or_insert_with(Vec::new)
+        },
+        None => engine_section.boot_args.get_or_insert_with(Vec::new)
+    };
+
+    let mut entries = get_nfs_entries(boot_args);
+    for volume in &volumes {
+        let entry = format!("{server}:{}", volume.paths);
+        match entries.iter().position(
+            |configured| get_entry_paths(configured) == Some(&volume.paths)
+        ) {
+            Some(position) => {
+                if entries[position] == entry {
+                    info!("Keeping volume {entry}");
+                } else {
+                    info!("Replacing volume {} by {entry}", entries[position]);
+                    entries[position] = entry;
+                }
+            },
+            None => {
+                info!("Adding volume {entry}");
+                entries.push(entry);
+            }
+        }
+    }
+    set_nfs_boot_arg(boot_args, &entries);
+
+    if ! write_flake_config(&config_file, &yaml_config) {
+        return false
+    }
+    info!("Updated {config_file}");
+    info!("The host path of a volume has to be exported, see:");
+    info!("  flake-ctl firecracker volume export --path <PATH>");
+    true
+}
+
+pub fn remove(
+    app: &str, volumes: &[String], instance: Option<&String>, usermode: bool
+) -> bool {
+    /*!
+    Delete the given volumes from the flake configuration
+
+    A volume is matched by its host and guest path, no matter
+    which server it is provided from. Sections which became empty
+    are dropped to leave the configuration as it was before the
+    volumes were added
+    !*/
+    let volumes = match get_volumes(volumes) {
+        Some(volumes) => volumes,
+        None => return false
+    };
+    let config_file = match get_flake_config_file(app, usermode) {
+        Some(config_file) => config_file,
+        None => return false
+    };
+    let instance = instance.map(|instance| get_instance_name(instance));
+    let mut yaml_config = match read_flake_config(&config_file) {
+        Some(yaml_config) => yaml_config,
+        None => return false
+    };
+    let engine_section = match get_engine_section(
+        &mut yaml_config, &config_file, "volume"
+    ) {
+        Some(engine_section) => engine_section,
+        None => return false
+    };
+
+    match instance.as_deref() {
+        Some(instance) => delete_instance_volumes(
+            engine_section, instance, &volumes
+        ),
+        None => {
+            if let Some(boot_args) = engine_section.boot_args.as_mut() {
+                delete_volumes(boot_args, &volumes);
+            } else {
+                report_unconfigured(&volumes);
+            }
+        }
+    }
+
+    if let Some(true) = engine_section.boot_args.as_ref().map(Vec::is_empty) {
+        engine_section.boot_args = None;
+    }
+    if let Some(true) = engine_section.instance.as_ref().map(HashMap::is_empty)
+    {
+        engine_section.instance = None;
+    }
+
+    if ! write_flake_config(&config_file, &yaml_config) {
+        return false
+    }
+    info!("Updated {config_file}");
+    true
+}
+
+// Volume is a host path provided to a VM through NFS
+struct Volume {
+    /// The 'HOST_PATH:GUEST_PATH' pair of the volume
+    paths: String
+}
+
+fn get_volumes(volumes: &[String]) -> Option<Vec<Volume>> {
+    /*!
+    Read the given volume specifications
+
+    An invalid specification lets the entire command fail, the
+    configuration is not touched in that case
+    !*/
+    volumes.iter().map(|volume| get_volume(volume)).collect()
+}
+
+fn get_volume(volume: &str) -> Option<Volume> {
+    /*!
+    Read the host and the guest path of the given volume
+
+    A volume is specified as 'HOST_PATH:GUEST_PATH'. The guest
+    path is the last element of the specification, everything in
+    front of it is the path on the host
+    !*/
+    let (host_path, guest_path) = match volume.rsplit_once(':') {
+        Some(paths) => paths,
+        None => {
+            error!("Invalid volume {volume:?}");
+            error!("Expected format: /some/local/path:/some/guest/path");
+            return None
+        }
+    };
+    for path in [host_path, guest_path] {
+        if ! path.starts_with('/') {
+            error!(
+                "Volume path {path:?} must be specified with an absolute path"
+            );
+            return None
+        }
+        // The volume becomes part of a kernel commandline option
+        // which is one word of a comma separated list
+        if path.contains(char::is_whitespace)
+            || path.contains(char::is_control)
+        {
+            error!("Volume path {path:?} contains unsupported characters");
+            return None
+        }
+        if path.contains(defaults::NFS_VOLUME_DELIMITER) {
+            error!(
+                "Volume path {path:?} must not contain {:?}",
+                defaults::NFS_VOLUME_DELIMITER
+            );
+            return None
+        }
+    }
+    Some(Volume { paths: format!("{host_path}:{guest_path}") })
+}
+
+fn delete_instance_volumes(
+    engine_section: &mut AppFireCrackerEngine, instance: &str,
+    volumes: &[Volume]
+) {
+    /*!
+    Delete the given volumes from the given instance
+
+    An instance section which provides nothing else is deleted
+    along with the volumes
+    !*/
+    let instances = match engine_section.instance.as_mut() {
+        Some(instances) => instances,
+        None => return report_unconfigured(volumes)
+    };
+    let instance_key = if instances.contains_key(instance) {
+        instance.to_string()
+    } else {
+        instance.trim_start_matches('@').to_string()
+    };
+    let instance_section = match instances.get_mut(&instance_key) {
+        Some(instance_section) => instance_section,
+        None => return report_unconfigured(volumes)
+    };
+    let is_empty = match instance_section.boot_args.as_mut() {
+        Some(boot_args) => {
+            delete_volumes(boot_args, volumes);
+            boot_args.is_empty()
+        },
+        None => {
+            report_unconfigured(volumes);
+            true
+        }
+    };
+    if is_empty {
+        instances.remove(&instance_key);
+    }
+}
+
+fn delete_volumes(boot_args: &mut Vec<String>, volumes: &[Volume]) {
+    /*!
+    Delete the given volumes from the given boot_args
+    !*/
+    let mut entries = get_nfs_entries(boot_args);
+    for volume in volumes {
+        let configured = entries.len();
+        entries.retain(
+            |entry| get_entry_paths(entry) != Some(&volume.paths)
+        );
+        if entries.len() == configured {
+            info!("No volume {} configured", volume.paths);
+        } else {
+            info!("Deleting volume {}", volume.paths);
+        }
+    }
+    set_nfs_boot_arg(boot_args, &entries);
+}
+
+fn report_unconfigured(volumes: &[Volume]) {
+    /*!
+    Tell that none of the given volumes is configured
+    !*/
+    for volume in volumes {
+        info!("No volume {} configured", volume.paths);
+    }
+}
+
+fn get_nfs_entries(boot_args: &[String]) -> Vec<String> {
+    /*!
+    Provide the volumes configured in the given boot_args
+
+    The volumes are provided as a comma separated list of the
+    nfs= option. More than one of these options is folded into
+    one list
+    !*/
+    boot_args.iter()
+        .filter(
+            |boot_arg| boot_arg_name(boot_arg) == defaults::NFS_VOLUME_BOOT_ARG
+        )
+        .filter_map(|boot_arg| boot_arg.split_once('='))
+        .flat_map(
+            |(_, volumes)| volumes.split(defaults::NFS_VOLUME_DELIMITER)
+        )
+        .map(str::trim)
+        .filter(|entry| ! entry.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+fn get_entry_paths(entry: &str) -> Option<&str> {
+    /*!
+    Provide the 'HOST_PATH:GUEST_PATH' pair of a volume entry
+
+    An entry is specified as 'NAME_OR_IP:HOST_PATH:GUEST_PATH',
+    the server it is provided from is its first element
+    !*/
+    entry.split_once(':').map(|(_, paths)| paths)
+}
+
+fn set_nfs_boot_arg(boot_args: &mut Vec<String>, entries: &[String]) {
+    /*!
+    Write the given volumes to the nfs= option of the given
+    boot_args
+
+    All volumes are kept in one option, sci reads them from a
+    single kernel commandline variable. The option keeps the
+    place it had and is deleted if no volume is left
+    !*/
+    let position = boot_args.iter().position(
+        |boot_arg| boot_arg_name(boot_arg) == defaults::NFS_VOLUME_BOOT_ARG
+    );
+    unset_boot_arg(boot_args, defaults::NFS_VOLUME_BOOT_ARG);
+    if entries.is_empty() {
+        return
+    }
+    let boot_arg = format!(
+        "{}={}",
+        defaults::NFS_VOLUME_BOOT_ARG,
+        entries.join(&defaults::NFS_VOLUME_DELIMITER.to_string())
+    );
+    match position {
+        Some(position) if position < boot_args.len() => {
+            boot_args.insert(position, boot_arg)
+        },
+        _ => boot_args.push(boot_arg)
+    }
+}
+
+fn get_nfs_server(
+    engine_section: &AppFireCrackerEngine, instance: Option<&str>,
+    config_file: &str
+) -> Option<Ipv4Addr> {
+    /*!
+    Provide the address the volumes are provided from
+
+    The volumes are exported by the host which the guest reaches
+    through the gateway of the private network. The address of
+    that gateway is part of the network setup of the flake and is
+    therefore read from its configuration
+    !*/
+    let gateway = instance
+        .and_then(|instance| get_instance_boot_args(engine_section, instance))
+        .and_then(get_boot_args_gateway)
+        .or_else(
+            || engine_section.boot_args.as_deref().and_then(
+                get_boot_args_gateway
+            )
+        );
+    if gateway.is_none() {
+        error!("No gateway address found in {config_file}");
+        error!("The address is read from the rd.route= boot option");
+        error!(
+            "Please run 'flake-ctl firecracker network add --app <APP>' first"
+        );
+    }
+    gateway
+}
+
+fn get_instance_boot_args<'a>(
+    engine_section: &'a AppFireCrackerEngine, instance: &str
+) -> Option<&'a [String]> {
+    /*!
+    Provide the boot_args of the given instance
+    !*/
+    let instances = engine_section.instance.as_ref()?;
+    let instance_section = instances.get(instance).or_else(
+        || instances.get(instance.trim_start_matches('@'))
+    )?;
+    instance_section.boot_args.as_deref()
+}
+
+fn get_boot_args_gateway(boot_args: &[String]) -> Option<Ipv4Addr> {
+    /*!
+    Read the gateway address from the rd.route= option
+
+    The option is written in the 'rd.route=GATEWAY/PREFIX::DEVICE'
+    format, a route without a prefix length is accepted as well
+    !*/
+    boot_args.iter()
+        .filter_map(|boot_arg| boot_arg.strip_prefix("rd.route="))
+        .filter_map(
+            |route_option| route_option.split(['/', ':']).next()
+        )
+        .find_map(|address| address.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        delete_volumes, get_boot_args_gateway, get_entry_paths, get_nfs_entries,
+        get_volume, get_volumes, set_nfs_boot_arg
+    };
+
+    fn boot_args(boot_args: &[&str]) -> Vec<String> {
+        boot_args.iter().map(ToString::to_string).collect()
+    }
+
+    #[test]
+    fn test_get_volume() {
+        assert_eq!(
+            "/host:/guest", get_volume("/host:/guest").unwrap().paths
+        );
+        // the guest path is the last element
+        assert_eq!(
+            "/host:with:colon:/guest",
+            get_volume("/host:with:colon:/guest").unwrap().paths
+        );
+        // no separator
+        assert!(get_volume("/host").is_none());
+        // relative paths
+        assert!(get_volume("host:/guest").is_none());
+        assert!(get_volume("/host:guest").is_none());
+        // empty guest path
+        assert!(get_volume("/host:").is_none());
+        // characters which break the volume list
+        assert!(get_volume("/host:/guest dir").is_none());
+        assert!(get_volume("/host,dir:/guest").is_none());
+    }
+
+    #[test]
+    fn test_get_volumes_fails_for_one_invalid_volume() {
+        let volumes = boot_args(&["/host:/guest", "invalid"]);
+        assert!(get_volumes(&volumes).is_none());
+    }
+
+    #[test]
+    fn test_get_nfs_entries() {
+        let configured = boot_args(&[
+            "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off",
+            "nfs=172.16.0.1:/host:/guest, 172.16.0.1:/other:/mnt",
+            "nfs=172.16.0.1:/more:/data"
+        ]);
+        assert_eq!(
+            vec![
+                "172.16.0.1:/host:/guest",
+                "172.16.0.1:/other:/mnt",
+                "172.16.0.1:/more:/data"
+            ],
+            get_nfs_entries(&configured)
+        );
+        assert!(get_nfs_entries(&boot_args(&["nfs="])).is_empty());
+    }
+
+    #[test]
+    fn test_get_entry_paths() {
+        assert_eq!(
+            Some("/host:/guest"), get_entry_paths("172.16.0.1:/host:/guest")
+        );
+        assert_eq!(None, get_entry_paths("no_separator"));
+    }
+
+    #[test]
+    fn test_set_nfs_boot_arg_keeps_the_place_of_the_option() {
+        let mut configured = boot_args(&[
+            "nfs=172.16.0.1:/host:/guest", "nameserver=8.8.8.8"
+        ]);
+        set_nfs_boot_arg(
+            &mut configured,
+            &boot_args(&["172.16.0.1:/host:/guest", "172.16.0.1:/other:/mnt"])
+        );
+        assert_eq!(
+            boot_args(&[
+                "nfs=172.16.0.1:/host:/guest,172.16.0.1:/other:/mnt",
+                "nameserver=8.8.8.8"
+            ]),
+            configured
+        );
+    }
+
+    #[test]
+    fn test_set_nfs_boot_arg_folds_and_appends() {
+        let mut configured = boot_args(&["nameserver=8.8.8.8"]);
+        set_nfs_boot_arg(
+            &mut configured, &boot_args(&["172.16.0.1:/host:/guest"])
+        );
+        assert_eq!(
+            boot_args(&["nameserver=8.8.8.8", "nfs=172.16.0.1:/host:/guest"]),
+            configured
+        );
+    }
+
+    #[test]
+    fn test_delete_volumes() {
+        let mut configured = boot_args(&[
+            "nfs=172.16.0.1:/host:/guest,172.16.0.1:/other:/mnt",
+            "nameserver=8.8.8.8"
+        ]);
+        delete_volumes(
+            &mut configured, &get_volumes(&boot_args(&["/other:/mnt"])).unwrap()
+        );
+        assert_eq!(
+            boot_args(&["nfs=172.16.0.1:/host:/guest", "nameserver=8.8.8.8"]),
+            configured
+        );
+        // the option is deleted with the last volume
+        delete_volumes(
+            &mut configured,
+            &get_volumes(&boot_args(&["/host:/guest"])).unwrap()
+        );
+        assert_eq!(boot_args(&["nameserver=8.8.8.8"]), configured);
+    }
+
+    #[test]
+    fn test_get_boot_args_gateway() {
+        assert_eq!(
+            Some("172.16.0.1".parse().unwrap()),
+            get_boot_args_gateway(&boot_args(&[
+                "ip=172.16.0.2::172.16.0.1:255.255.255.0::eth0:off",
+                "rd.route=172.16.0.1/24::eth0"
+            ]))
+        );
+        assert_eq!(
+            None,
+            get_boot_args_gateway(&boot_args(&["rd.route=default::eth0"]))
+        );
+        assert_eq!(None, get_boot_args_gateway(&boot_args(&["ip=dhcp"])));
+    }
+}

--- a/package/flake-pilot.spec
+++ b/package/flake-pilot.spec
@@ -270,6 +270,8 @@ fi
 %doc /usr/share/man/man8/flake-ctl-firecracker-network-remove.8.gz
 %doc /usr/share/man/man8/flake-ctl-firecracker-volume-export.8.gz
 %doc /usr/share/man/man8/flake-ctl-firecracker-volume-release.8.gz
+%doc /usr/share/man/man8/flake-ctl-firecracker-volume-add.8.gz
+%doc /usr/share/man/man8/flake-ctl-firecracker-volume-remove.8.gz
 /usr/bin/firecracker-pilot
 %doc /usr/share/man/man8/firecracker-pilot.8.gz
 /usr/lib/flake-pilot/sci


### PR DESCRIPTION
Add firecracker volume add/remove commands to assign a formerly exported NFS volume to a flake and its instances