### PR TITLE
Drop use of pivot_root in sci

### DIFF
--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -27,11 +27,18 @@ use std::env;
 pub const PROMPT: &str = "\\[\\]\\u@\\h: > ";
 pub const SSHD: &str = "/usr/sbin/sshd";
 pub const SWITCH_ROOT: &str = "/sbin/switch_root";
-pub const PIVOT_ROOT: &str = "/sbin/pivot_root";
+// Path of sci in the guest. sci calls itself through the switch
+// root to become the init process of the overlay root
+pub const SCI: &str = "/usr/sbin/sci";
+// Marker in the environment of sci which tells that the switch
+// root into the overlay was done already
+pub const OVERLAY_SWITCHED: &str = "sci_overlay_switched";
 pub const OVERLAY_ROOT: &str = "/overlayroot/rootfs";
 pub const OVERLAY_UPPER: &str = "/overlayroot/rootfs_upper";
 pub const OVERLAY_WORK: &str = "/overlayroot/rootfs_work";
 pub const PROBE_MODULE: &str = "/sbin/modprobe";
+// Mount table of the kernel
+pub const PROC_MOUNTS: &str = "/proc/self/mounts";
 pub const MOUNT_TOOL: &str = "mount";
 // Filesystem type and separator of the volume specification
 // given in the nfs=... cmdline variable

--- a/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/defaults.rs
@@ -34,6 +34,8 @@ pub const SCI: &str = "/usr/sbin/sci";
 // root into the overlay was done already
 pub const OVERLAY_SWITCHED: &str = "sci_overlay_switched";
 pub const OVERLAY_ROOT: &str = "/overlayroot/rootfs";
+// Permissions of the root directory of the instance
+pub const ROOT_DIR_MODE: u32 = 0o755;
 pub const OVERLAY_UPPER: &str = "/overlayroot/rootfs_upper";
 pub const OVERLAY_WORK: &str = "/overlayroot/rootfs_work";
 pub const PROBE_MODULE: &str = "/sbin/modprobe";

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -79,7 +79,9 @@ fn main() {
 
     if provided via the overlay_root=/dev/block_device kernel boot
     parameter, sci also prepares the root filesystem as an overlay
-    using the given block device for writing.
+    using the given block device for writing. The overlay is made
+    the root filesystem with a switch root, which calls sci again
+    as the init process of the new root.
 
     if provided via the nfs=... kernel boot parameter, sci mounts
     the listed NFS volumes before the command is called.
@@ -87,7 +89,6 @@ fn main() {
     setup_logger();
 
     let mut args: Vec<String> = vec![];
-    let mut call: Command;
     let mut do_exec = false;
     let mut ok = true;
 
@@ -144,7 +145,15 @@ fn main() {
 
     // mount overlay if requested
     match env::var("overlay_root").ok() {
-        Some(overlay) => {
+        Some(overlay) => if env::var(defaults::OVERLAY_SWITCHED).is_ok() {
+            // the overlay is the root filesystem of this instance.
+            // sci switched into it and got called again as its init
+            // process, thus there is nothing left to prepare
+            debug(&format!(
+                "{} is the root filesystem", defaults::OVERLAY_ROOT
+            ));
+            setup_resolver_link();
+        } else {
             // overlay device is specified, mount the device and
             // prepare the folder structure
             let mut modprobe = Command::new(defaults::PROBE_MODULE);
@@ -216,7 +225,7 @@ fn main() {
                     }
                 }
             }
-            // Call specified command through switch root into the overlay
+            // Make the overlay the new root
             if ok {
                 move_mounts(defaults::OVERLAY_ROOT);
                 let root = Path::new(defaults::OVERLAY_ROOT);
@@ -235,40 +244,33 @@ fn main() {
                     }
                 }
             }
-            if do_exec {
-                call = Command::new(defaults::SWITCH_ROOT);
-                call.arg(".").arg(&args[0]);
-            } else {
-                call = Command::new(&args[0]);
-                if ok {
-                    let mut pivot = Command::new(defaults::PIVOT_ROOT);
-                    pivot.arg(".").arg("mnt");
-                    debug(&format!(
-                        "SCI CALL: {} -> {:?}",
-                        defaults::PIVOT_ROOT, pivot.get_args()
-                    ));
-                    match pivot.status() {
-                        Ok(_) => {
-                            debug(&format!(
-                                "{} is now the new root", defaults::OVERLAY_ROOT
-                            ));
-                            ok = true;
-                        },
-                        Err(error) => {
-                            debug(&format!("Failed to pivot_root: {error}"));
-                            ok = false;
-                        }
-                    }
-                    mount_basic_fs();
-                    setup_resolver_link();
-                }
+            if ok {
+                // Switch root into the overlay. sci calls itself as
+                // the init process of the new root, thus the setup
+                // of the instance and the command call itself is
+                // done with the overlay as the root filesystem.
+                // On success this replaces the running process and
+                // main() starts over inside of the overlay
+                let mut switch_root = Command::new(defaults::SWITCH_ROOT);
+                switch_root.arg(".").arg(defaults::SCI)
+                    .env(defaults::OVERLAY_SWITCHED, "true");
+                debug(&format!(
+                    "SCI CALL: {} -> {:?}",
+                    defaults::SWITCH_ROOT, switch_root.get_args()
+                ));
+                let error = switch_root.exec();
+                debug(&format!("Failed to switch_root: {error}"));
+                ok = false;
             }
         },
         None => {
-            // Call command in current environment
-            call = Command::new(&args[0]);
+            debug("No overlay_root=... cmdline parameter in env");
         }
     };
+
+    // Call the command in the current root. With an overlay this
+    // is the overlay root, sci switched into it before
+    let mut call = Command::new(&args[0]);
 
     // mount nfs volumes if requested
     mount_nfs_volumes();
@@ -1439,29 +1441,50 @@ fn mount_nfs_volume(source: &str, target: &str) {
 fn mount_basic_fs() {
     /*!
     Mount standard filesystems
+
+    A filesystem which is already mounted is skipped. This is the
+    case after the switch root into the overlay because the switch
+    root moves these filesystems along into the new root
     !*/
-    match Mount::builder().fstype("proc").mount("proc", "/proc") {
-        Ok(_) => debug("Mounted proc on /proc"),
-        Err(error) => {
-            debug(&format!("Failed to mount /proc [skipped]: {error}"));
+    let basic_fs = [
+        ("proc", "/proc"),
+        ("sysfs", "/sys"),
+        ("devtmpfs", "/dev"),
+        ("devpts", "/dev/pts")
+    ];
+    for (fstype, mount_point) in basic_fs.iter() {
+        if is_mounted(mount_point) {
+            debug(&format!("{mount_point} is already mounted [skipped]"));
+            continue
+        }
+        match Mount::builder().fstype(*fstype).mount(*fstype, mount_point) {
+            Ok(_) => debug(&format!("Mounted {fstype} on {mount_point}")),
+            Err(error) => {
+                debug(&format!("Failed to mount {mount_point}: {error}"));
+            }
         }
     }
-    match Mount::builder().fstype("sysfs").mount("sysfs", "/sys") {
-        Ok(_) => debug("Mounted sysfs on /sys"),
+}
+
+fn is_mounted(mount_point: &str) -> bool {
+    /*!
+    Check if something is mounted on the given mount point
+
+    The information is read from the mount table of the kernel.
+    A mount table which cannot be read, e.g because /proc is not
+    mounted yet, reports the mount point as not mounted
+    !*/
+    match fs::read_to_string(defaults::PROC_MOUNTS) {
+        Ok(mount_table) => mount_table.lines().any(
+            |mount_record| mount_record
+                .split_whitespace()
+                .nth(1) == Some(mount_point)
+        ),
         Err(error) => {
-            debug(&format!("Failed to mount /sys: {error}"));
-        }
-    }
-    match Mount::builder().fstype("devtmpfs").mount("devtmpfs", "/dev") {
-        Ok(_) => debug("Mounted devtmpfs on /dev"),
-        Err(error) => {
-            debug(&format!("Failed to mount /dev: {error}"));
-        }
-    }
-    match Mount::builder().fstype("devpts").mount("devpts", "/dev/pts") {
-        Ok(_) => debug("Mounted devpts on /dev/pts"),
-        Err(error) => {
-            debug(&format!("Failed to mount /dev/pts: {error}"));
+            debug(&format!(
+                "Failed to read {}: {}", defaults::PROC_MOUNTS, error
+            ));
+            false
         }
     }
 }

--- a/firecracker-pilot/guestvm-tools/sci/src/main.rs
+++ b/firecracker-pilot/guestvm-tools/sci/src/main.rs
@@ -29,7 +29,7 @@ extern crate shell_words;
 pub mod defaults;
 
 use std::env;
-use std::os::unix::fs::symlink;
+use std::os::unix::fs::{symlink, PermissionsExt};
 use std::path::Path;
 use std::process::Command;
 use std::os::unix::process::CommandExt;
@@ -224,6 +224,14 @@ fn main() {
                         ok = false;
                     }
                 }
+            }
+            if ok {
+                // The overlay takes the permissions of its upper
+                // directory, which was created with the umask of
+                // sci. Set them to the standard mode of the root
+                // directory such that the new / is not world
+                // writable
+                set_root_permissions(defaults::OVERLAY_ROOT);
             }
             // Make the overlay the new root
             if ok {
@@ -1462,6 +1470,25 @@ fn mount_basic_fs() {
             Err(error) => {
                 debug(&format!("Failed to mount {mount_point}: {error}"));
             }
+        }
+    }
+}
+
+fn set_root_permissions(root: &str) {
+    /*!
+    Set the permissions of the given root directory
+
+    The root directory of the instance is expected to be readable
+    and searchable for everyone but writable only for the owner
+    !*/
+    match fs::set_permissions(
+        root, fs::Permissions::from_mode(defaults::ROOT_DIR_MODE)
+    ) {
+        Ok(_) => debug(&format!(
+            "Set mode {:o} on {}", defaults::ROOT_DIR_MODE, root
+        )),
+        Err(error) => {
+            debug(&format!("Failed to set permissions on {root}: {error}"));
         }
     }
 }

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -253,7 +253,7 @@ pub async fn pull_component_image(
                 let proc_in_image = format!(
                     "{}/{}", tmp_dir_path, "/proc"
                 );
-                // required for pivot
+                // required for the switch root into the overlay
                 let sys_in_image = format!(
                     "{}/{}", tmp_dir_path, "/sys"
                 );
@@ -263,10 +263,6 @@ pub async fn pull_component_image(
                 // required for PTS allocation
                 let dev_pts_in_image = format!(
                     "{}/{}", tmp_dir_path, "/dev/pts"
-                );
-                // required for overlay root allocation
-                let mnt_in_image = format!(
-                    "{}/{}", tmp_dir_path, "/mnt"
                 );
                 if ! Path::new(&sci_in_image).exists() {
                     info!("Copying sci to rootfs...");
@@ -294,10 +290,6 @@ pub async fn pull_component_image(
                     return result
                 }
                 if ! Path::new(&dev_pts_in_image).exists() && ! mkdir(&dev_pts_in_image, "root") {
-                    umount(&tmp_dir_path, "root");
-                    return result
-                }
-                if ! Path::new(&mnt_in_image).exists() && ! mkdir(&mnt_in_image, "root") {
                     umount(&tmp_dir_path, "root");
                     return result
                 }


### PR DESCRIPTION
sci used the pivot_root (chroot) procedure to switch into the new root (/) in case of an overlay root such that sci as a    process can stay active. This root layout however, can confuse applications running on top it. Therefore this commit changes the procedure into a standard switch_root followed by a re-exec of sci to serve as a real init process.