### PR TITLE
Dynamically select private network

### DIFF
--- a/doc/flake-ctl-firecracker-network-add.rst
+++ b/doc/flake-ctl-firecracker-network-add.rst
@@ -42,10 +42,12 @@ The command performs the following steps:
         - rd.route=172.16.0.1/24::eth0
         - nameserver=8.8.8.8
 
-   Gateway, netmask and name server are not configurable, they
-   describe the private network between the host and the VMs and
-   are compiled into the command. The address is a free address
-   of that network, see ADDRESSES below
+   Gateway and netmask describe the private network between the
+   host and the VMs. That network is the one selected with
+   **flake-ctl-firecracker-network-init**(8), the example above
+   shows the preferred network ``172.16.0.0/24``. The name server
+   is not configurable, it is compiled into the command. The
+   address is a free address of the network, see ADDRESSES below
 
 2. Create the TAP device of the application
 
@@ -77,10 +79,11 @@ As the setup changes the network configuration of the host, the
 commands are called through **sudo**. The calling user therefore
 needs the permission to run them as root.
 
-The outgoing interface is the one the host setup was created for
-with **flake-ctl-firecracker-network-init**(8). If there is no
-record of it, e.g because the host setup was created manually, the
-interface of the default route is used.
+Private network and outgoing interface are the ones the host setup
+was created for with **flake-ctl-firecracker-network-init**(8). If
+there is no record of them, e.g because the host setup was created
+manually, the interface of the default route and a free private
+network are used.
 
 The steps only take effect if the host is prepared for NAT
 networking. Please run **flake-ctl firecracker network init**
@@ -118,10 +121,12 @@ ADDRESSES
 ---------
 
 The address handed out to an application is the lowest free
-address of the ``172.16.0.0/24`` network. An address which is
-already used by another flake registration is never handed out
-twice, and an application which is already configured keeps the
-address it has.
+address of the private network of the host setup, which is
+``172.16.0.0/24`` unless the host uses that network already. An
+address which is already used by another flake registration is
+never handed out twice, and an application which is already
+configured keeps the address it has as long as it belongs to that
+network.
 
 Only registrations which can be read take part in this. In user
 mode these are the registrations of the calling user and the

--- a/doc/flake-ctl-firecracker-network-init.rst
+++ b/doc/flake-ctl-firecracker-network-init.rst
@@ -31,13 +31,16 @@ act as a router and to translate the sender address of the VM traffic
 to an address which is reachable from the outside. The command creates
 this setup by:
 
-1. Enabling IPv4 forwarding on the host
+1. Selecting the private network between the host and the VMs, see
+   NETWORK below
+
+2. Enabling IPv4 forwarding on the host
 
    .. code:: bash
 
       sudo sh -c "echo 1 > /proc/sys/net/ipv4/ip_forward"
 
-2. Setting up Network Address Translation (NAT) on the given
+3. Setting up Network Address Translation (NAT) on the given
    outgoing interface
 
    .. code:: bash
@@ -50,10 +53,11 @@ outgoing interface. As the setup changes the network configuration of
 the host, the commands are called through **sudo**. The calling user
 therefore needs the permission to run them as root.
 
-The given interface is recorded in the network configuration file.
-Connecting an application to the host network with
-**flake-ctl-firecracker-network-add**(8) reads it from there and
-routes the traffic of that application to the same interface.
+The given interface and the selected network are recorded in the
+network configuration file. Connecting an application to the host
+network with **flake-ctl-firecracker-network-add**(8) reads them from
+there, takes the address of the application from the same network and
+routes its traffic to the same interface.
 
 Rules which are already active are not created again. This allows to
 call the command more than once without stacking up duplicates of the
@@ -71,6 +75,35 @@ network configuration of the VM itself is part of the flake
 configuration of the application. See **flake-ctl-firecracker-register**(8)
 and the ``Firecracker Networking`` section of the flake-pilot README
 for the complete setup.
+
+NETWORK
+-------
+
+The VMs of a host live in one private network which only exists
+between the TAP devices of the instances and the VMs behind them. The
+preferred network is ``172.16.0.0/24``. If the host is connected to a
+network which overlaps with it, the next free ``/24`` network of the
+private address space is taken instead, in the order:
+
+* ``172.16.0.0`` ... ``172.31.255.0``
+* ``192.168.0.0`` ... ``192.168.255.0``
+* ``10.0.0.0`` ... ``10.255.255.0``
+
+The networks of the host are read from the addresses of its
+interfaces and from its routing table, the TAP devices of the flakes
+are left out. The first address of the selected network, e.g
+``172.16.0.1``, becomes the gateway of the VMs and is configured on
+every TAP device.
+
+The selected network is recorded and a recorded network is kept as
+long as the host does not use it. This keeps the applications which
+are connected to it reachable and allows to create the host setup
+again, e.g after a reboot, without moving the applications to another
+network. Only a recorded network which collides with a network of the
+host, e.g because the host was connected to it afterwards, is
+replaced. In that case the applications have to be connected again
+with **flake-ctl-firecracker-network-add**(8) to receive an address
+of the new network.
 
 OPTIONS
 -------

--- a/doc/flake-ctl-firecracker-volume-export.rst
+++ b/doc/flake-ctl-firecracker-volume-export.rst
@@ -23,7 +23,10 @@ DESCRIPTION
 
 Export the given absolute host path through NFS for firecracker guest
 access. The command writes a flake-pilot managed entry to
-``/etc/exports`` for the private firecracker network ``172.16.0.0/24``.
+``/etc/exports`` for the private firecracker network. That network is
+the one of the host setup created by
+**flake-ctl-firecracker-network-init**(8), which is ``172.16.0.0/24``
+unless the host uses that network already.
 
 If the ``nfs-server`` systemd service is not running yet, it is
 started. If it is already running, the export table is reloaded so the
@@ -44,6 +47,8 @@ FILES
 -----
 
 * /etc/exports
+* /etc/flakes/network.yaml
+* $HOME/.config/flakes/network.yaml
 
 EXAMPLE
 -------

--- a/doc/user_guide/firecracker_networking.rst
+++ b/doc/user_guide/firecracker_networking.rst
@@ -33,13 +33,33 @@ The Concept
 All VM applications of a host live in one private network which does
 not exist outside of that host:
 
-* Private network: ``172.16.0.0/24``
-* Gateway, the host side of the network: ``172.16.0.1``
+* Private network: ``172.16.0.0/24`` if the host allows it, see below
+* Gateway, the host side of the network: the first address of that
+  network, e.g ``172.16.0.1``
 * Netmask: ``255.255.255.0``
 * Name server: ``8.8.8.8``
 * Name of the network interface in the guest: ``eth0``
 
-These values are compiled into ``flake-ctl`` and are not
+The private network is selected when the host is prepared with
+``flake-ctl firecracker network init``. The preferred network is
+``172.16.0.0/24``. If the host is connected to a network which
+overlaps with it, the next free ``/24`` network of the private
+address space is taken instead, in the order ``172.16.0.0`` to
+``172.31.255.0``, ``192.168.0.0`` to ``192.168.255.0`` and
+``10.0.0.0`` to ``10.255.255.0``. The networks of the host are read
+from the addresses of its interfaces and from its routing table, the
+TAP devices of the flakes are left out.
+
+The selected network is recorded along with the outgoing interface
+and a recorded network is kept as long as the host does not use it.
+Thus all applications of a host share the same network and the
+network stays the same across reboots. Only if the recorded network
+collides with a network of the host, e.g because the host was
+connected to it afterwards, ``init`` selects another one. The
+applications then have to be connected again to receive an address of
+the new network.
+
+The other values are compiled into ``flake-ctl`` and are not
 configurable. Only the address of an application is variable. It is
 assigned once, when the application is connected, and is written to
 its flake configuration. Therefore an application keeps its address
@@ -102,11 +122,12 @@ Prepare the Host
 
    flake-ctl firecracker network init --outgoing-interface eth0
 
-Enables IP forwarding and creates the NAT rules on the given
-interface, the one the traffic of the VMs leaves the host through.
-This is done once per host, and again after a reboot, not once per
-application. The interface is recorded such that the following
-commands know where to route the traffic to.
+Selects the private network of the VMs, enables IP forwarding and
+creates the NAT rules on the given interface, the one the traffic of
+the VMs leaves the host through. This is done once per host, and
+again after a reboot, not once per application. Network and interface
+are recorded such that the following commands use the same network
+and know where to route the traffic to.
 
 .. warning::
 
@@ -173,7 +194,9 @@ The flake configuration for the registered ``claude`` app from
    vi ~/.config/flakes/claude.yaml
 
 Connecting the app and its instances leads to the following network
-related settings:
+related settings. The addresses are the ones of the preferred
+network, on a host which uses ``172.16.0.0/24`` already the
+addresses of the selected network show up instead:
 
 .. code-block:: yaml
 

--- a/doc/user_guide/firecracker_volumes.rst
+++ b/doc/user_guide/firecracker_volumes.rst
@@ -44,8 +44,10 @@ Export a Local Path
    flake-ctl firecracker volume export --path /some/local/path
 
 Writes a ``flake-pilot`` managed entry for the given path to
-``/etc/exports``, restricted to the private firecracker network
-``172.16.0.0/24``. If the ``nfs-server`` systemd service is not
+``/etc/exports``, restricted to the private firecracker network of
+the host setup, which is ``172.16.0.0/24`` unless the host uses that
+network already, see :ref:`firecracker-networking`. If the
+``nfs-server`` systemd service is not
 running yet it is started, otherwise the export table is reloaded so
 the new export becomes effective right away.
 

--- a/flake-ctl/src/defaults.rs
+++ b/flake-ctl/src/defaults.rs
@@ -114,8 +114,6 @@ pub const NFS_EXPORTS_FILE:&str =
     "/etc/exports";
 pub const NFS_SERVER_SERVICE:&str =
     "nfs-server";
-pub const NFS_CLIENT_NETWORK:&str =
-    "172.16.0.0/24";
 pub const NFS_EXPORT_OPTIONS:&str =
     "rw,sync,no_subtree_check,no_root_squash,insecure";
 // Kernel commandline option sci reads the NFS volumes of a VM
@@ -138,15 +136,33 @@ pub const NETWORK_CONFIG:&str =
 // home directory of the user calling the program
 pub const NETWORK_CONFIG_USER:&str =
     ".config/flakes/firecracker/network.yaml";
-// Static setup of the private network between the host and the
-// VMs. The addresses are not configurable, they only exist
-// between the TAP device of an instance and the VM behind it.
-// The traffic to the outside world is masqueraded and therefore
-// leaves the host with the address of the outgoing interface
-pub const NETWORK_GATEWAY:&str =
-    "172.16.0.1";
-pub const NETWORK_NETMASK:&str =
-    "255.255.255.0";
+// Setup of the private network between the host and the VMs.
+// The addresses only exist between the TAP device of an instance
+// and the VM behind it. The traffic to the outside world is
+// masqueraded and therefore leaves the host with the address of
+// the outgoing interface.
+//
+// The network to use is selected when the host setup is created
+// and is recorded along with it. The preferred network is taken
+// if the host is not connected to it already, in all other cases
+// a free network from the ranges below is taken
+pub const NETWORK_PREFERRED:&str =
+    "172.16.0.0";
+// Ranges of private networks a free network is searched in if
+// the preferred network conflicts with a network of the host.
+// Each entry provides the first network of the range and the
+// number of networks in it. The networks of a range follow each
+// other in steps of NETWORK_PREFIX_LEN, e.g 172.16.0.0 is
+// followed by 172.16.1.0. The ranges are searched in the order
+// they are listed here
+pub const NETWORK_RANGES:&[(&str, u32)] = &[
+    // 172.16.0.0 ... 172.31.255.0
+    ("172.16.0.0", 4096),
+    // 192.168.0.0 ... 192.168.255.0
+    ("192.168.0.0", 256),
+    // 10.0.0.0 ... 10.255.255.0
+    ("10.0.0.0", 65536)
+];
 pub const NETWORK_PREFIX_LEN:u8 =
     24;
 // Prefix length of the host route which connects the address of

--- a/flake-ctl/src/firecracker.rs
+++ b/flake-ctl/src/firecracker.rs
@@ -34,6 +34,7 @@ use std::fs;
 use std::fs::File;
 
 use crate::defaults;
+use crate::network;
 use crate::{app, app_config};
 
 use crate::fetch::{fetch_file, send_request};
@@ -690,14 +691,22 @@ pub fn run_as(program: &str, user: &str) -> Command {
     call
 }
 
-pub fn export_volume(path: &str) -> bool {
+pub fn export_volume(path: &str, usermode: bool) -> bool {
     /*!
     Export the given host path via NFS for firecracker guests
+
+    The export is limited to the private network between the
+    host and the VMs, which is the network of the host setup
+    created by 'flake-ctl firecracker network init'
     !*/
     if ! validate_volume_export_path(path, true) {
         return false
     }
-    if ! update_nfs_exports(path, true) {
+    let client_network = match network::get_client_network(usermode) {
+        Some(client_network) => client_network,
+        None => return false
+    };
+    if ! update_nfs_exports(path, Some(&client_network)) {
         return false
     }
     if nfs_server_is_running() {
@@ -714,7 +723,7 @@ pub fn release_volume(path: &str) -> bool {
     if ! validate_volume_export_path(path, false) {
         return false
     }
-    if ! update_nfs_exports(path, false) {
+    if ! update_nfs_exports(path, None) {
         return false
     }
     restart_nfs_server()
@@ -746,25 +755,31 @@ fn validate_volume_export_path(path: &str, must_exist: bool) -> bool {
     true
 }
 
-fn update_nfs_exports(path: &str, present: bool) -> bool {
+fn update_nfs_exports(path: &str, client_network: Option<&str>) -> bool {
     /*!
     Add or remove the flake-pilot managed NFS export entry
+
+    The entry is created for the given client network. Without
+    a network the entry is deleted
     !*/
     let exports = match read_nfs_exports() {
         Some(exports) => exports,
         None => return false
     };
-    let desired_entry = nfs_export_entry(path);
+    let desired_entry = client_network.map(
+        |client_network| nfs_export_entry(path, client_network)
+    );
     let managed_entries: Vec<&str> = exports.lines().filter(
         |line| is_flake_pilot_nfs_export(line, path)
     ).collect();
-    if present && managed_entries.len() == 1
-        && managed_entries[0].trim() == desired_entry
-    {
-        info!("Keeping existing NFS export for {path}");
-        return true
-    }
-    if ! present && managed_entries.is_empty() {
+    if let Some(ref desired_entry) = desired_entry {
+        if managed_entries.len() == 1
+            && managed_entries[0].trim() == *desired_entry
+        {
+            info!("Keeping existing NFS export for {path}");
+            return true
+        }
+    } else if managed_entries.is_empty() {
         info!("No flake-pilot NFS export entry found for {path}");
         return true
     }
@@ -772,11 +787,12 @@ fn update_nfs_exports(path: &str, present: bool) -> bool {
     let mut updated_lines: Vec<String> = exports.lines().filter(
         |line| ! is_flake_pilot_nfs_export(line, path)
     ).map(ToOwned::to_owned).collect();
-    if present {
-        info!("Exporting {path} through NFS...");
-        updated_lines.push(desired_entry);
-    } else {
-        info!("Releasing NFS export for {path}...");
+    match desired_entry {
+        Some(desired_entry) => {
+            info!("Exporting {path} through NFS...");
+            updated_lines.push(desired_entry);
+        },
+        None => info!("Releasing NFS export for {path}...")
     }
 
     let mut updated_exports = updated_lines.join("\n");
@@ -833,14 +849,14 @@ fn write_nfs_exports(exports: &str) -> bool {
     run_ok(&mut call, &format!("install {}", defaults::NFS_EXPORTS_FILE))
 }
 
-fn nfs_export_entry(path: &str) -> String {
+fn nfs_export_entry(path: &str, client_network: &str) -> String {
     /*!
     Provide the managed NFS export line for the given path
     !*/
     format!(
         "{} {}({}) {}",
         escape_nfs_export_path(path),
-        defaults::NFS_CLIENT_NETWORK,
+        client_network,
         defaults::NFS_EXPORT_OPTIONS,
         FLAKE_PILOT_NFS_EXPORT_MARKER
     )

--- a/flake-ctl/src/main.rs
+++ b/flake-ctl/src/main.rs
@@ -176,7 +176,7 @@ async fn main() -> Result<ExitCode, Box<dyn std::error::Error>> {
                 cli::Firecracker::Volume { command } => {
                     match &command {
                         cli::Volume::Export { path } => {
-                            if ! firecracker::export_volume(path) {
+                            if ! firecracker::export_volume(path, user) {
                                 return Ok(ExitCode::FAILURE)
                             }
                         },

--- a/flake-ctl/src/network.rs
+++ b/flake-ctl/src/network.rs
@@ -22,11 +22,14 @@
 // SOFTWARE.
 //
 use flakes::config::get_flakes_dir;
+use flakes::defaults::TAP_DEVICE_PREFIX;
 use flakes::network::get_tap_name;
 use glob::glob;
 use serde::{Serialize, Deserialize};
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
+use std::iter;
 use std::net::Ipv4Addr;
 use std::path::Path;
 use std::process::{Command, Stdio};
@@ -42,6 +45,20 @@ use crate::setup::user_home;
 #[derive(Debug, Serialize, Deserialize)]
 pub struct NetworkConfig {
     pub outgoing_interface: String,
+    // The private network between the host and the VMs in its
+    // ADDRESS/PREFIX_LEN notation. Records which were written
+    // before the network became selectable provide none, they
+    // were created for the preferred network
+    #[serde(default = "preferred_network_record")]
+    pub network: String,
+}
+
+fn preferred_network_record() -> String {
+    /*!
+    Provide the network of a record which predates the selection
+    of the network
+    !*/
+    get_preferred_network().to_string()
 }
 
 pub fn init(outgoing_interface: &str, usermode: bool) -> bool {
@@ -58,22 +75,34 @@ pub fn init(outgoing_interface: &str, usermode: bool) -> bool {
     therefore performed via sudo. It is not persistent and has to
     be created again after a reboot of the host.
 
-    The outgoing interface is stored such that the setup of the
-    single flakes, done by add(), knows where to route their
-    traffic to.
+    The outgoing interface and the private network between the host
+    and the VMs are stored such that the setup of the single flakes,
+    done by add(), uses the same network and knows where to route
+    its traffic to.
 
     Please note, the setup assumes there is no other firewall
     software active on the host. If the host firewall is managed
     by another tool, the rules have to be created with that tool
     instead
     !*/
+    let network = match select_network(usermode) {
+        Some(network) => network,
+        None => return false
+    };
     if ! enable_ip_forward() {
         return false
     }
     if ! setup_nat(outgoing_interface) {
         return false
     }
-    write_network_config(outgoing_interface, usermode)
+    if ! write_network_config(outgoing_interface, &network, usermode) {
+        return false
+    }
+    info!("Host is prepared for VM networking:");
+    info!("  network: {network}");
+    info!("  gateway: {}", network.gateway());
+    info!("  outgoing interface: {outgoing_interface}");
+    true
 }
 
 pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
@@ -98,10 +127,14 @@ pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
         Some(outgoing_interface) => outgoing_interface,
         None => return false
     };
+    let network = match get_network(usermode) {
+        Some(network) => network,
+        None => return false
+    };
 
     // 1. the flake configuration
     let address = match configure_flake(
-        &flake.config_file, flake.instance.as_deref(), usermode
+        &flake.config_file, flake.instance.as_deref(), &network, usermode
     ) {
         Some(address) => address,
         None => return false
@@ -113,7 +146,7 @@ pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
     }
 
     // 3. the route from the TAP device to the outside world
-    if ! connect_tap(&flake.tap, &outgoing_interface) {
+    if ! connect_tap(&flake.tap, &outgoing_interface, &network) {
         return false
     }
 
@@ -124,7 +157,7 @@ pub fn add(app: &str, instance: Option<&String>, usermode: bool) -> bool {
 
     info!("Application {app} is connected:");
     info!("  address: {address}");
-    info!("  gateway: {}", defaults::NETWORK_GATEWAY);
+    info!("  gateway: {}", network.gateway());
     info!("  tap device: {}", flake.tap);
     info!("  outgoing interface: {outgoing_interface}");
     if let Some(instance) = flake.instance {
@@ -271,7 +304,8 @@ pub fn get_instance_name(instance: &str) -> String {
 }
 
 fn configure_flake(
-    config_file: &str, instance: Option<&str>, usermode: bool
+    config_file: &str, instance: Option<&str>, network: &Ipv4Network,
+    usermode: bool
 ) -> Option<Ipv4Addr> {
     /*!
     Write the static network setup to the flake configuration
@@ -288,14 +322,19 @@ fn configure_flake(
     )?;
 
     // An address which is already configured for this flake is
-    // kept, in all other cases a free one is taken
-    let address = match get_configured_address(engine_section, instance) {
+    // kept as long as it belongs to the network of the setup,
+    // in all other cases a free one is taken
+    let address = match get_configured_address(engine_section, instance)
+        .filter(|address| network.contains(address))
+    {
         Some(address) => {
             info!("Keeping configured address {address}");
             address
         },
         None => {
-            let address = get_free_address(&get_used_addresses(usermode))?;
+            let address = get_free_address(
+                network, &get_used_addresses(usermode)
+            )?;
             info!("Assigning address {address}");
             address
         }
@@ -304,14 +343,13 @@ fn configure_flake(
     let ip_option = format!(
         "ip={}::{}:{}::{}:off",
         address,
-        defaults::NETWORK_GATEWAY,
-        defaults::NETWORK_NETMASK,
+        network.gateway(),
+        network.netmask(),
         defaults::NETWORK_GUEST_INTERFACE
     );
     let route_option = format!(
-        "rd.route={}/{}::{}",
-        defaults::NETWORK_GATEWAY,
-        defaults::NETWORK_PREFIX_LEN,
+        "rd.route={}::{}",
+        network.gateway_route(),
         defaults::NETWORK_GUEST_INTERFACE
     );
     let dns_option = format!("nameserver={}", defaults::NETWORK_DNS);
@@ -562,33 +600,22 @@ fn get_used_addresses(usermode: bool) -> Vec<Ipv4Addr> {
     used
 }
 
-fn get_free_address(used: &[Ipv4Addr]) -> Option<Ipv4Addr> {
+fn get_free_address(
+    network: &Ipv4Network, used: &[Ipv4Addr]
+) -> Option<Ipv4Addr> {
     /*!
     Provide the lowest address of the private network which is
     not in use. The network and broadcast address as well as the
     address of the gateway are never handed out
     !*/
-    let gateway = get_gateway();
-    let network = gateway.octets();
-    for host in 1..=254 {
-        let address = Ipv4Addr::new(network[0], network[1], network[2], host);
+    let gateway = network.gateway();
+    for address in network.hosts() {
         if address != gateway && ! used.contains(&address) {
             return Some(address)
         }
     }
-    error!("No free address left in {}/{}",
-        gateway, defaults::NETWORK_PREFIX_LEN
-    );
+    error!("No free address left in {network}");
     None
-}
-
-fn get_gateway() -> Ipv4Addr {
-    /*!
-    Provide the address of the host side of the private network
-    !*/
-    defaults::NETWORK_GATEWAY.parse().unwrap_or_else(
-        |_| panic!("Invalid gateway default: {}", defaults::NETWORK_GATEWAY)
-    )
 }
 
 pub fn set_boot_arg(boot_args: &mut Vec<String>, boot_arg: String) {
@@ -717,6 +744,422 @@ fn get_default_route_interface() -> Option<String> {
     None
 }
 
+// RecordedNetwork is the network of the host setup record
+enum RecordedNetwork {
+    /// The network the record provides
+    Network(Ipv4Network),
+    /// There is no record of a host setup
+    Missing,
+    /// The record exists but provides no valid network
+    Invalid
+}
+
+fn read_recorded_network(usermode: bool) -> RecordedNetwork {
+    /*!
+    Read the private network from the host setup record
+    !*/
+    let network_config = match read_network_config(usermode) {
+        Some(network_config) => network_config,
+        None => return RecordedNetwork::Missing
+    };
+    match Ipv4Network::parse(&network_config.network) {
+        Some(network) => RecordedNetwork::Network(network),
+        None => {
+            error!(
+                "Invalid network {:?} in the network setup record",
+                network_config.network
+            );
+            RecordedNetwork::Invalid
+        }
+    }
+}
+
+fn select_network(usermode: bool) -> Option<Ipv4Network> {
+    /*!
+    Provide the private network to create the host setup for
+
+    A network which is already recorded is kept as long as the
+    host does not use it. This keeps the flakes which are
+    connected to it reachable and allows to create the host
+    setup again, e.g after a reboot. A recorded network which
+    collides with a network of the host, e.g because the host
+    was connected to it afterwards, is replaced
+    !*/
+    match read_recorded_network(usermode) {
+        RecordedNetwork::Network(network) => {
+            if ! network_collides(&network) {
+                info!("Keeping recorded network {network}");
+                return Some(network)
+            }
+            warn!("Recorded network {network} collides with a network \
+                of the host"
+            );
+            warn!("The applications which are connected to it have to \
+                be connected again"
+            );
+            let network = get_free_network()?;
+            info!("Selecting network {network}");
+            Some(network)
+        },
+        RecordedNetwork::Missing => {
+            let network = get_free_network()?;
+            info!("Selecting network {network}");
+            Some(network)
+        },
+        RecordedNetwork::Invalid => None
+    }
+}
+
+fn get_network(usermode: bool) -> Option<Ipv4Network> {
+    /*!
+    Provide the private network between the host and the VMs
+
+    This is the network the host setup was created for. If there
+    is no record of it, e.g because the setup was created
+    manually, a network which does not collide with the networks
+    of the host is used
+    !*/
+    match read_recorded_network(usermode) {
+        RecordedNetwork::Network(network) => Some(network),
+        RecordedNetwork::Missing => {
+            let network = get_free_network()?;
+            info!("No network setup record found");
+            info!("Using free network: {network}");
+            Some(network)
+        },
+        RecordedNetwork::Invalid => None
+    }
+}
+
+pub fn get_client_network(usermode: bool) -> Option<String> {
+    /*!
+    Provide the private network between the host and the VMs in
+    the notation used to allow the VMs as clients, e.g in the
+    NFS exports of the host
+    !*/
+    Some(get_network(usermode)?.to_string())
+}
+
+fn get_free_network() -> Option<Ipv4Network> {
+    /*!
+    Provide a private network which does not collide with the
+    networks the host is connected to
+
+    The preferred network is taken if the host does not use it,
+    in all other cases the fallback ranges are searched for a
+    free network
+    !*/
+    select_free_network(&get_host_networks()?)
+}
+
+fn select_free_network(host_networks: &[Ipv4Network]) -> Option<Ipv4Network> {
+    /*!
+    Provide the first of the private networks to select from
+    which does not overlap with one of the given networks
+    !*/
+    for candidate in get_network_candidates() {
+        if ! host_networks.iter().any(
+            |host_network| host_network.overlaps(&candidate)
+        ) {
+            return Some(candidate)
+        }
+    }
+    error!("No free private network left on this host");
+    None
+}
+
+fn network_collides(network: &Ipv4Network) -> bool {
+    /*!
+    Check if the given network overlaps with one of the networks
+    the host is connected to. A host setup which cannot be read
+    is not reported as a collision
+    !*/
+    match get_host_networks() {
+        Some(host_networks) => host_networks.iter().any(
+            |host_network| host_network.overlaps(network)
+        ),
+        None => false
+    }
+}
+
+fn get_network_candidates() -> impl Iterator<Item = Ipv4Network> {
+    /*!
+    Provide the private networks to select from, in the order of
+    their preference. The preferred network comes first, followed
+    by the networks of the fallback ranges
+    !*/
+    let preferred = get_preferred_network();
+    let step = 1 << (32 - defaults::NETWORK_PREFIX_LEN as u32);
+    let fallback = defaults::NETWORK_RANGES.iter().flat_map(
+        move |(first_network, count)| {
+            let first = u32::from(get_default_network(first_network).address);
+            (0..*count).map(
+                move |index| Ipv4Network::new(
+                    Ipv4Addr::from(first + index * step),
+                    defaults::NETWORK_PREFIX_LEN
+                )
+            )
+        }
+    );
+    iter::once(preferred).chain(
+        fallback.filter(move |network| *network != preferred)
+    )
+}
+
+fn get_preferred_network() -> Ipv4Network {
+    /*!
+    Provide the network which is used if the host allows it
+    !*/
+    get_default_network(defaults::NETWORK_PREFERRED)
+}
+
+fn get_default_network(address: &str) -> Ipv4Network {
+    /*!
+    Provide the network of one of the compiled in addresses
+    !*/
+    match address.parse() {
+        Ok(address) => Ipv4Network::new(
+            address, defaults::NETWORK_PREFIX_LEN
+        ),
+        Err(_) => panic!("Invalid network default: {}", address)
+    }
+}
+
+fn get_host_networks() -> Option<Vec<Ipv4Network>> {
+    /*!
+    Provide the IPv4 networks the host is connected to
+
+    The networks are read from the addresses of the interfaces
+    of the host and from its routing table. The TAP devices of
+    the flakes are left out, they are part of the setup this
+    information is collected for
+    !*/
+    let mut networks = get_interface_networks()?;
+    networks.extend(get_route_networks()?);
+    Some(networks)
+}
+
+fn get_interface_networks() -> Option<Vec<Ipv4Network>> {
+    /*!
+    Provide the networks of the addresses of the host interfaces
+    !*/
+    let mut call = Command::new(defaults::IP_TOOL);
+    call.arg("-4").arg("-oneline").arg("addr").arg("show");
+    Some(get_address_list_networks(&run_output(&mut call)?))
+}
+
+fn get_address_list_networks(addresses: &str) -> Vec<Ipv4Network> {
+    /*!
+    Read the networks from the output of 'ip -4 -oneline addr show'
+
+    The expected format of a line is:
+    'INDEX: DEVICE inet ADDRESS/PREFIX_LEN ...'
+    !*/
+    let mut networks = Vec::new();
+    for line in addresses.lines() {
+        let device = line.split_whitespace().nth(1).unwrap_or_default();
+        if is_flake_tap_device(device) {
+            continue
+        }
+        networks.extend(
+            get_field_value(line, "inet").and_then(Ipv4Network::parse)
+        );
+    }
+    networks
+}
+
+fn get_route_networks() -> Option<Vec<Ipv4Network>> {
+    /*!
+    Provide the networks the host has a route for
+    !*/
+    let mut call = Command::new(defaults::IP_TOOL);
+    call.arg("-4").arg("-oneline").arg("route").arg("show");
+    Some(get_route_list_networks(&run_output(&mut call)?))
+}
+
+fn get_route_list_networks(routes: &str) -> Vec<Ipv4Network> {
+    /*!
+    Read the networks from the output of 'ip -4 -oneline route show'
+
+    The expected format of a line is:
+    'DESTINATION [via GATEWAY] dev DEVICE ...'. The destination of
+    the default route is reported as 'default', it describes no
+    network and is therefore skipped
+    !*/
+    let mut networks = Vec::new();
+    for line in routes.lines() {
+        let device = get_field_value(line, "dev").unwrap_or_default();
+        if is_flake_tap_device(device) {
+            continue
+        }
+        networks.extend(
+            line.split_whitespace().next().and_then(Ipv4Network::parse)
+        );
+    }
+    networks
+}
+
+fn is_flake_tap_device(device: &str) -> bool {
+    /*!
+    Check if the given device is a TAP device of a flake
+
+    Devices attached to a parent device are reported in the
+    'NAME@PARENT' notation, in the address list the name of the
+    device is followed by a colon
+    !*/
+    device
+        .split('@').next().unwrap_or_default()
+        .trim_end_matches(':')
+        .starts_with(TAP_DEVICE_PREFIX)
+}
+
+fn get_field_value<'a>(line: &'a str, name: &str) -> Option<&'a str> {
+    /*!
+    Provide the value following the given field name in a line
+    of the iproute2 output
+    !*/
+    let mut fields = line.split_whitespace();
+    while let Some(field) = fields.next() {
+        if field == name {
+            return fields.next()
+        }
+    }
+    None
+}
+
+fn run_output(call: &mut Command) -> Option<String> {
+    /*!
+    Run the given call and provide its standard output
+    !*/
+    match call.output() {
+        Ok(output) => {
+            if ! output.status.success() {
+                error!(
+                    "Failed to execute {:?}: {}", call, output.status
+                );
+                return None
+            }
+            Some(String::from_utf8_lossy(&output.stdout).to_string())
+        },
+        Err(error) => {
+            error!("Failed to execute {call:?}: {error:?}");
+            None
+        }
+    }
+}
+
+// Ipv4Network is an IPv4 network in its ADDRESS/PREFIX_LEN notation
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct Ipv4Network {
+    /// Address of the network itself, e.g 172.16.0.0
+    address: Ipv4Addr,
+    /// Number of leading bits which form the network part
+    prefix_len: u8
+}
+
+impl Ipv4Network {
+    fn new(address: Ipv4Addr, prefix_len: u8) -> Ipv4Network {
+        /*!
+        Provide the network of the given prefix length the given
+        address belongs to
+        !*/
+        let prefix_len = prefix_len.min(32);
+        Ipv4Network {
+            address: Ipv4Addr::from(
+                u32::from(address) & Ipv4Network::netmask_bits(prefix_len)
+            ),
+            prefix_len
+        }
+    }
+
+    fn parse(network: &str) -> Option<Ipv4Network> {
+        /*!
+        Read a network from its ADDRESS/PREFIX_LEN notation. An
+        address given without a prefix length is a single host
+        !*/
+        let (address, prefix_len) = match network.split_once('/') {
+            Some((address, prefix_len)) => (address, prefix_len.parse().ok()?),
+            None => (network, 32)
+        };
+        if prefix_len > 32 {
+            return None
+        }
+        Some(Ipv4Network::new(address.parse().ok()?, prefix_len))
+    }
+
+    fn netmask_bits(prefix_len: u8) -> u32 {
+        /*!
+        Provide the netmask of the given prefix length
+        !*/
+        match prefix_len {
+            0 => 0,
+            prefix_len => u32::MAX << (32 - prefix_len as u32)
+        }
+    }
+
+    fn netmask(&self) -> Ipv4Addr {
+        /*!
+        Provide the netmask of the network, e.g 255.255.255.0
+        !*/
+        Ipv4Addr::from(Ipv4Network::netmask_bits(self.prefix_len))
+    }
+
+    fn gateway(&self) -> Ipv4Addr {
+        /*!
+        Provide the address of the host side of the network. It
+        is the first address of the network and is configured on
+        the TAP device of every instance
+        !*/
+        Ipv4Addr::from(u32::from(self.address) + 1)
+    }
+
+    fn gateway_route(&self) -> String {
+        /*!
+        Provide the route to the gateway as the guest expects it
+        in its rd.route= option, e.g 172.16.0.1/24
+        !*/
+        format!("{}/{}", self.gateway(), self.prefix_len)
+    }
+
+    fn broadcast(&self) -> u32 {
+        /*!
+        Provide the last address of the network
+        !*/
+        u32::from(self.address) | ! Ipv4Network::netmask_bits(self.prefix_len)
+    }
+
+    fn hosts(&self) -> impl Iterator<Item = Ipv4Addr> {
+        /*!
+        Provide the addresses of the network which can be handed
+        out. The network and the broadcast address are not part
+        of them
+        !*/
+        (u32::from(self.address) + 1..self.broadcast()).map(Ipv4Addr::from)
+    }
+
+    fn contains(&self, address: &Ipv4Addr) -> bool {
+        /*!
+        Check if the given address belongs to the network
+        !*/
+        u32::from(*address) & Ipv4Network::netmask_bits(self.prefix_len)
+            == u32::from(self.address)
+    }
+
+    fn overlaps(&self, other: &Ipv4Network) -> bool {
+        /*!
+        Check if the given network shares addresses with this one
+        !*/
+        u32::from(self.address) <= other.broadcast()
+            && u32::from(other.address) <= self.broadcast()
+    }
+}
+
+impl fmt::Display for Ipv4Network {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        write!(formatter, "{}/{}", self.address, self.prefix_len)
+    }
+}
+
 fn get_network_config_file(usermode: bool) -> Option<String> {
     /*!
     Provide the path of the host network setup record
@@ -752,19 +1195,23 @@ fn read_network_config(usermode: bool) -> Option<NetworkConfig> {
     }
 }
 
-fn write_network_config(outgoing_interface: &str, usermode: bool) -> bool {
+fn write_network_config(
+    outgoing_interface: &str, network: &Ipv4Network, usermode: bool
+) -> bool {
     /*!
     Record the host network setup
 
     The record allows the setup of the single flakes to find the
-    interface their traffic has to be routed to
+    interface their traffic has to be routed to and the private
+    network their addresses are taken from
     !*/
     let config_file = match get_network_config_file(usermode) {
         Some(config_file) => config_file,
         None => return false
     };
     let network_config = NetworkConfig {
-        outgoing_interface: outgoing_interface.to_string()
+        outgoing_interface: outgoing_interface.to_string(),
+        network: network.to_string()
     };
     let yaml_data = match serde_yaml::to_string(&network_config) {
         Ok(yaml_data) => yaml_data,
@@ -979,7 +1426,9 @@ fn get_tuntap_device_name(tuntap_list_line: &str) -> &str {
         .trim()
 }
 
-fn connect_tap(tap: &str, outgoing_interface: &str) -> bool {
+fn connect_tap(
+    tap: &str, outgoing_interface: &str, network: &Ipv4Network
+) -> bool {
     /*!
     Connect the given TAP device to the outgoing interface
 
@@ -987,9 +1436,7 @@ fn connect_tap(tap: &str, outgoing_interface: &str) -> bool {
     traffic is allowed to pass to the outgoing interface. The
     way back is covered by the rules created with init()
     !*/
-    let gateway = format!(
-        "{}/{}", defaults::NETWORK_GATEWAY, defaults::NETWORK_PREFIX_LEN
-    );
+    let gateway = network.gateway_route();
     if address_exists(tap, &gateway) {
         info!("Keeping existing address {gateway} on {tap}");
     } else {
@@ -1117,5 +1564,149 @@ fn run_ok(call: &mut Command, action: &str) -> bool {
             error!("Failed to {action}: {error:?}");
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use super::{
+        get_address_list_networks, get_free_address, get_network_candidates,
+        get_preferred_network, get_route_list_networks, select_free_network,
+        Ipv4Network
+    };
+
+    fn network(network: &str) -> Ipv4Network {
+        Ipv4Network::parse(network).unwrap()
+    }
+
+    fn address(address: &str) -> Ipv4Addr {
+        address.parse().unwrap()
+    }
+
+    #[test]
+    fn test_parse_network() {
+        let private = network("172.16.0.0/24");
+        assert_eq!("172.16.0.0/24", private.to_string());
+        assert_eq!(address("255.255.255.0"), private.netmask());
+        assert_eq!(address("172.16.0.1"), private.gateway());
+        assert_eq!("172.16.0.1/24", private.gateway_route());
+        // the address is reduced to the network it belongs to
+        assert_eq!(private, network("172.16.0.42/24"));
+        // an address without a prefix length is a single host
+        assert_eq!("10.0.0.1/32", network("10.0.0.1").to_string());
+        assert_eq!(None, Ipv4Network::parse("172.16.0.0/33"));
+        assert_eq!(None, Ipv4Network::parse("172.16.0.0/foo"));
+        assert_eq!(None, Ipv4Network::parse("default"));
+    }
+
+    #[test]
+    fn test_network_contains_and_overlaps() {
+        let private = network("172.16.0.0/24");
+        assert!(private.contains(&address("172.16.0.1")));
+        assert!(! private.contains(&address("172.16.1.1")));
+        // a network which is part of another one overlaps with it
+        assert!(private.overlaps(&network("172.16.0.0/16")));
+        assert!(network("172.16.0.0/16").overlaps(&private));
+        assert!(private.overlaps(&network("172.16.0.5")));
+        assert!(! private.overlaps(&network("172.16.1.0/24")));
+        assert!(! private.overlaps(&network("192.168.0.0/16")));
+    }
+
+    #[test]
+    fn test_network_hosts() {
+        let hosts: Vec<Ipv4Addr> = network("172.16.0.0/24").hosts().collect();
+        // the network and the broadcast address are not handed out
+        assert_eq!(254, hosts.len());
+        assert_eq!(address("172.16.0.1"), hosts[0]);
+        assert_eq!(address("172.16.0.254"), hosts[253]);
+    }
+
+    #[test]
+    fn test_get_free_address() {
+        let private = network("10.1.2.0/24");
+        // the gateway address is never handed out
+        assert_eq!(
+            Some(address("10.1.2.2")), get_free_address(&private, &[])
+        );
+        assert_eq!(
+            Some(address("10.1.2.4")),
+            get_free_address(&private, &[
+                address("10.1.2.2"), address("10.1.2.3")
+            ])
+        );
+        // addresses of another network do not take part
+        assert_eq!(
+            Some(address("10.1.2.2")),
+            get_free_address(&private, &[address("172.16.0.2")])
+        );
+        let used: Vec<Ipv4Addr> = private.hosts().collect();
+        assert_eq!(None, get_free_address(&private, &used));
+    }
+
+    #[test]
+    fn test_get_network_candidates() {
+        let candidates: Vec<Ipv4Network> = get_network_candidates()
+            .take(3).collect();
+        assert_eq!(
+            vec![
+                network("172.16.0.0/24"),
+                network("172.16.1.0/24"),
+                network("172.16.2.0/24")
+            ],
+            candidates
+        );
+        // the preferred network is only offered once
+        assert_eq!(
+            1, get_network_candidates()
+                .filter(|network| *network == get_preferred_network()).count()
+        );
+    }
+
+    #[test]
+    fn test_select_free_network() {
+        // the preferred network is taken if the host allows it
+        assert_eq!(
+            Some(network("172.16.0.0/24")),
+            select_free_network(&[network("192.168.0.0/24")])
+        );
+        // a network of the host is not handed out
+        assert_eq!(
+            Some(network("172.16.1.0/24")),
+            select_free_network(&[network("172.16.0.0/24")])
+        );
+        // this includes networks which only overlap with it. A
+        // host which uses the entire first range gets a network
+        // of the next one
+        assert_eq!(
+            Some(network("192.168.0.0/24")),
+            select_free_network(&[network("172.16.0.0/12")])
+        );
+    }
+
+    #[test]
+    fn test_get_address_list_networks() {
+        let addresses = "\
+1: lo    inet 127.0.0.1/8 scope host lo\\       valid_lft forever
+2: eth0    inet 172.16.0.5/24 brd 172.16.0.255 scope global eth0\\       valid_lft forever
+3: tap-app    inet 172.16.0.1/24 scope global tap-app\\       valid_lft forever
+";
+        assert_eq!(
+            vec![network("127.0.0.0/8"), network("172.16.0.0/24")],
+            get_address_list_networks(addresses)
+        );
+    }
+
+    #[test]
+    fn test_get_route_list_networks() {
+        let routes = "\
+default via 192.168.1.1 dev eth0 proto dhcp metric 100
+192.168.1.0/24 dev eth0 proto kernel scope link src 192.168.1.23
+172.16.0.2 dev tap-app scope link
+";
+        assert_eq!(
+            vec![network("192.168.1.0/24")], get_route_list_networks(routes)
+        );
     }
 }


### PR DESCRIPTION
The network is no longer hardcoded, it is selected at setup with a preference for 172.16.0.0/24. The selected network is recorded in network.yaml such that other commands like network add or volume add knows about the initialized network. This Fixes #115